### PR TITLE
[DM-7219] Add Conda recipe for SWIG 3.0.10.

### DIFF
--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -38,8 +38,22 @@ if [[ ! -f "$PWD/miniconda/.installed" ]]; then
 	# Install prerequisites
 	#
 	export PATH="$PWD/miniconda/bin:$PATH"
-	conda install conda-build jinja2 requests sqlalchemy pip --yes
+	conda install conda-build==1.20.0 jinja2 requests sqlalchemy pip --yes
 
+	#
+	# Conda build and install SWIG 3.0.10
+	#
+	if [ -z "${CONDA_LSST_OLD_SWIG}" ]; then
+ 	   conda build ./etc/recipes/swig
+	   conda install --use-local swig --yes
+	else
+	   conda install swig==3.0.2 --yes
+	   sed -i "" "s/==3\.0\.10/==3\.0\.2/g" ./etc/config.yaml
+	fi
+
+	#
+	# Pip install requests_file
+	#
 	pip install requests_file
 
 	# marker that we're done

--- a/etc/config.yaml
+++ b/etc/config.yaml
@@ -163,8 +163,8 @@ pin_versions:
     build: "2.7.*"
     run:   "2.7.*"
   swig:
-    build: "==3.0.2"
-    run:   "==3.0.2"
+    build: "==3.0.10"
+    run:   "==3.0.10"
   scipy:
     build: "0.16.*"
     run:   ">=0.16"

--- a/etc/recipes/swig/build.sh
+++ b/etc/recipes/swig/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+export CPPFLAGS=-I$PREFIX/include
+
+./configure --prefix=$PREFIX
+make -j${CPU_COUNT}
+#make check
+make install

--- a/etc/recipes/swig/meta.yaml
+++ b/etc/recipes/swig/meta.yaml
@@ -1,0 +1,28 @@
+package:
+  name: swig
+  version: 3.0.10
+
+source:
+  fn: swig-3.0.10.tar.gz   [unix]
+  url: http://prdownloads.sourceforge.net/swig/swig-3.0.10.tar.gz  [unix]
+  sha1: c672b8535394cfb204c70de7c66e69fb20a95647 [unix]
+
+build:
+  detect_binary_files_with_prefix: True    [unix]
+
+requirements:
+  build:
+    - pcre      [unix]
+    - python    [unix]
+  run:
+    - pcre      [unix]
+
+test:
+  commands:
+    - swig -help
+
+about:
+  home: http://www.swig.org/
+  license: GPLv3
+  summary: C/C++ parser code generator
+


### PR DESCRIPTION
- Add SWIG recipe to etc/recipes/swig. The upstream recipe
  is not available due to the conda-build version and a conflict.
- Default to SWIG 3.0.10 in bootstrap.sh.
- Add CONDA_LSST_OLD_SWIG environment variable to install
  SWIG 3.0.2, if needed.
- Update etc/config.yaml to SWIG 3.0.10.
  
  modified:   bin/bootstrap.sh
  modified:   etc/config.yaml
  new file:   etc/recipes/swig/build.sh
  new file:   etc/recipes/swig/meta.yaml
