### PR TITLE
[DM-7340] Configure mariadb and mariadbclient to build on Mac OS X.

### DIFF
--- a/conda_lsst/config.py
+++ b/conda_lsst/config.py
@@ -311,7 +311,7 @@ def _get_our_channels(regex):
 	from urlparse import urljoin
 	import conda.config
 
-	chans = [ urljoin(conda.config.channel_alias, u).rstrip('/ ') + '/' for u in conda.config.get_rc_urls() ]
+	chans = [ urljoin(conda.config.context.channel_alias, u).rstrip('/ ') + '/' for u in conda.config.get_rc_urls() ]
 	chans = [ chan for chan in chans if re.match(regex, chan) ]
 	return chans
 

--- a/conda_lsst/config.py
+++ b/conda_lsst/config.py
@@ -264,6 +264,7 @@ class Config(object):
 		config['dependencies'] = _deps
 
 		# Set member variables
+                self.root_dir = root_dir
 		self.output_dir = expand_path(root_dir, config['output_dir'])
 		self.recipe_db_dir = expand_path(root_dir, config['recipe_db_dir'])
 		self.additional_recipes_dir = expand_path(root_dir, config['additional_recipes_dir'])
@@ -280,6 +281,7 @@ class Config(object):
 		# obtaining the source
 		self.git_upstreams = config['git-upstreams']
 		self.override_gitrev = config['override_gitrev']
+                self.prefer_etc_recipes = config['prefer_etc_recipes']
 
 		# Upload support
 		self.channel_server       = config['upload']['server']

--- a/etc/config.yaml
+++ b/etc/config.yaml
@@ -47,6 +47,7 @@ internal_products:
   sqlalchemy:
   requests:
   astropy:
+  cmake:
 
 #
 # EUPS products we should ignore alltogether

--- a/etc/config.yaml
+++ b/etc/config.yaml
@@ -63,6 +63,12 @@ skip_products:
 lsst_prefix: "lsst-"
 
 #
+# Use Conda recipes found in etc/recipes first before using remote
+# git repositories.
+#
+prefer_etc_recipes: yes
+
+#
 # Explicit overrides for mapping of EUPS->conda product names
 #
 eups_to_conda_map:

--- a/etc/recipes/lsst-mariadb/build.sh
+++ b/etc/recipes/lsst-mariadb/build.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+#
+# The conda-build build script to build eupspkg-packaged code
+#
+
+# Find the true source root: conda tries to be helpful and
+# changes into the first non-empty directory given a github repository; 
+export SRC_DIR=$(git rev-parse --show-toplevel)
+cd $SRC_DIR
+
+#
+# Adjust OS-X specific parameters
+#
+if [[ "$OSTYPE" == darwin* ]]; then
+	# - Can't run earlier than Mountain Lion (10.8)
+	# (astrometry.net build breaks (at least))
+	# - Can't run earlier than Mavericks
+	# (boost won't build otherwise; 10.9 switched to libc++)
+    	export MACOSX_DEPLOYMENT_TARGET=""
+	export CMAKE_OSX_SYSROOT="/"
+	# Make sure there's enough room in binaries for the install_name_tool magic
+	# to work
+	export LDFLAGS="$LDFLAGS -headerpad_max_install_names"
+
+#	# Make sure binaries (e.g., tests) get built with enough
+#	# padding in the header for the install_name_tool to work
+#	# (sconsUtils adds the contents of this variable to CCFLAGS and LINKFLAGS)
+#	export ARCHFLAGS='-headerpad_max_install_names'
+
+	if [[ "$(ld -v 2>&1 | grep -Eow 'PROJECT:.*')" == "PROJECT:ld64-264.3.101" ]]; then
+		echo "You're running XCode 7.3, with a broken linker (version ld64-264.3.101): implementing a workaround for the @rpath expansion bug".
+		XCODE_73_RPATH_BUG=1
+	fi
+fi
+
+# Add Anaconda's library path to DYLD_LIBRARY_PATH, to make the libraries visible
+# to the builds
+if [[ "$OSTYPE" == darwin* ]]; then
+	export DYLD_FALLBACK_LIBRARY_PATH="$DYLD_LIBRARY_PATH:$CONDA_DEFAULT_ENV/lib"
+else
+	export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$CONDA_DEFAULT_ENV/lib"
+fi
+
+
+############################################################################
+# Build the package using eupspkg
+#
+PRODUCT=$(basename ups/*.table .table)
+EUPS_VERSION="10.1.11.lsst2"
+PREFIX="$PREFIX/opt/lsst/$PRODUCT"
+
+# initialize EUPS
+source eups-setups.sh
+
+# prepare
+eupspkg PREFIX="$PREFIX" PRODUCT="$PRODUCT" VERSION="$EUPS_VERSION" FLAVOR=generic prep
+
+# setup dependencies (just for the environmental variables, really)
+# FIXME: a command should be added to eupspkg to just get the envvars
+eups list
+
+setup -r .
+export
+
+#
+# make debugging easier -- if the build breaks, make it possible to chdir into the
+# build directory and run ./_build.sh <verb>
+#
+cat > _build.sh <<-EOT
+	#!/bin/bash
+	$(export)
+
+	# XCODE_73_RPATH_BUG workaround?
+	if [[ "$XCODE_73_RPATH_BUG" == 1 ]]; then
+	    trap '{ rm -f @rpath; rm -rf "$PREFIX/@rpath"; }' EXIT
+	    ln -fs "\$CONDA_DEFAULT_ENV/lib" @rpath
+	fi
+
+	PRODUCT="$PRODUCT"
+	EUPS_VERSION="$EUPS_VERSION"
+
+	eupspkg PREFIX="$PREFIX" PRODUCT="$PRODUCT" VERSION="$EUPS_VERSION" FLAVOR=generic "\$@"
+EOT
+chmod +x _build.sh
+
+# configure, build, install, declare to EUPS
+./_build.sh config
+./_build.sh build
+./_build.sh install
+./_build.sh decl
+
+# Add EUPS tags.  The tags will be stored in a file in the product's ups
+# dir; it will be merged by the pre-link.sh script with the EUPS database
+# when the package is installed
+TAGFILE="$EUPS_PATH/ups_db/global.tags"
+for TAG in current conda; do
+	# FIXME: This should be handled by the post-link/pre-delete script !!!
+	test -f "$TAGFILE" && echo -n " " >> "$TAGFILE"
+	echo -n "$TAG" >> "$TAGFILE"
+
+	eups declare -t $TAG "$PRODUCT" "$EUPS_VERSION"
+done
+mv "$TAGFILE" "$PREFIX/ups"
+
+
+############################################################################
+# Binary preparation, directory cleanups
+#
+
+# compile all .py and .cfg files so they don't get picked up as new by conda
+# when building other packages
+if [[ -d "$PREFIX/python" ]]; then
+	# don't fail in case of syntax errors, etc.
+	"$PYTHON" -m compileall "$PREFIX/python" || true
+fi
+if ls "$PREFIX/ups"/*.cfg 1> /dev/null 2>&1; then
+	"$PYTHON" -m py_compile "$PREFIX/ups"/*.cfg
+fi

--- a/etc/recipes/lsst-mariadb/meta.yaml
+++ b/etc/recipes/lsst-mariadb/meta.yaml
@@ -1,0 +1,37 @@
+#
+# Run `conda build .` to build this package
+#
+
+package:
+  name: "lsst-mariadb"
+  version: "0.10.1.11.2"
+
+source:
+  git_rev: "fe7e7b24e7db405979d8827a650cdf4e8a22ec26"
+  git_url: "https://github.com/LSST/mariadb"
+
+
+build:
+  number: 0
+  string: "0"
+#  binary_relocation: false
+
+requirements:
+  build:
+    - cmake
+    - eups >=2.0.2
+    - gcc ==4.8.5                   # [not osx]
+    - nomkl                         #
+    - openssl
+    - patchelf ==0.8                # [not osx]
+
+  run:
+    - eups >=2.0.2
+    - libgcc >=4.8.5                # [not osx]
+    - nomkl                         #
+    - openssl
+
+about:
+  home: "https://github.com/LSST/mariadb"
+#  license: GPLv2
+#  summary: A version manager tracking product dependencies

--- a/etc/recipes/lsst-mariadb/pre-link.sh
+++ b/etc/recipes/lsst-mariadb/pre-link.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Fail immediately if something's wrong
+set -e
+
+# Write into this file for anything that the user should see
+OUT="$PREFIX/.messages.txt"
+
+# Adjust SOURCE_DIR (for convenience)
+SOURCE_DIR="$SOURCE_DIR/opt/lsst/mariadb"
+
+# Add $PREFIX/bin to $PATH; it's not on the path when run
+# in _build environment (is this a bug in conda-build?)
+export PATH="$PREFIX/bin:$PATH"
+
+# initialize EUPS
+source eups-setups.sh
+
+# Merge the EUPS tags used by this package with the global EUPS database
+#
+IFS=':' read -ra EUPS_PATH_ARR <<< "$EUPS_PATH"
+TAGFILE="${EUPS_PATH_ARR[0]}/ups_db/global.tags"
+
+# We need to merge the tags in the existing global.tags file, with any new
+# tags that our product needs:
+#
+# What the magic below does (in order):
+#   * cat both files, ensuring there's a newline between them
+#   * convert whitespaces to newlines
+#   * sort & run uniq
+#   * remove any empty lines
+#   * translate newlines back to whitespaces
+touch "$TAGFILE"						# make sure it exists
+awk 'FNR==1{print ""}1' "$SOURCE_DIR/ups/global.tags" "$TAGFILE" | 	\
+		tr ' ' '\n' | \
+		sort -u     | \
+		awk 'NF'    | \
+		tr '\n' ' ' \
+		> "$TAGFILE".tmp
+
+# Move the new file into place
+mv "$TAGFILE".tmp "$TAGFILE"

--- a/etc/recipes/lsst-mariadbclient/build.sh
+++ b/etc/recipes/lsst-mariadbclient/build.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+#
+# The conda-build build script to build eupspkg-packaged code
+#
+
+# Find the true source root: conda tries to be helpful and
+# changes into the first non-empty directory given a github repository; 
+
+export SRC_DIR=$(git rev-parse --show-toplevel)
+cd $SRC_DIR
+
+#
+# Adjust OS-X specific parameters
+#
+if [[ "$OSTYPE" == darwin* ]]; then
+	# - Can't run earlier than Mountain Lion (10.8)
+	# (astrometry.net build breaks (at least))
+	# - Can't run earlier than Mavericks
+	# (boost won't build otherwise; 10.9 switched to libc++)
+	export MACOSX_DEPLOYMENT_TARGET=""
+	export CMAKE_OSX_SYSROOT="/"
+	# Make sure there's enough room in binaries for the install_name_tool magic
+	# to work
+	export LDFLAGS="$LDFLAGS -headerpad_max_install_names"
+
+#	# Make sure binaries (e.g., tests) get built with enough
+#	# padding in the header for the install_name_tool to work
+#	# (sconsUtils adds the contents of this variable to CCFLAGS and LINKFLAGS)
+#	export ARCHFLAGS='-headerpad_max_install_names'
+
+	if [[ "$(ld -v 2>&1 | grep -Eow 'PROJECT:.*')" == "PROJECT:ld64-264.3.101" ]]; then
+		echo "You're running XCode 7.3, with a broken linker (version ld64-264.3.101): implementing a workaround for the @rpath expansion bug".
+		XCODE_73_RPATH_BUG=1
+	fi
+fi
+
+# Add Anaconda's library path to DYLD_LIBRARY_PATH, to make the libraries visible
+# to the builds
+if [[ "$OSTYPE" == darwin* ]]; then
+	export DYLD_FALLBACK_LIBRARY_PATH="$DYLD_LIBRARY_PATH:$CONDA_DEFAULT_ENV/lib"
+else
+	export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$CONDA_DEFAULT_ENV/lib"
+fi
+
+
+############################################################################
+# Build the package using eupspkg
+#
+PRODUCT=$(basename ups/*.table .table)
+EUPS_VERSION="10.1.11.lsst3"
+PREFIX="$PREFIX/opt/lsst/$PRODUCT"
+
+# initialize EUPS
+source eups-setups.sh
+
+# prepare
+eupspkg PREFIX="$PREFIX" PRODUCT="$PRODUCT" VERSION="$EUPS_VERSION" FLAVOR=generic prep
+
+# setup dependencies (just for the environmental variables, really)
+# FIXME: a command should be added to eupspkg to just get the envvars
+eups list
+
+setup -r .
+export
+
+#
+# make debugging easier -- if the build breaks, make it possible to chdir into the
+# build directory and run ./_build.sh <verb>
+#
+cat > _build.sh <<-EOT
+	#!/bin/bash
+	$(export)
+
+	# XCODE_73_RPATH_BUG workaround?
+	if [[ "$XCODE_73_RPATH_BUG" == 1 ]]; then
+	    trap '{ rm -f @rpath; rm -rf "$PREFIX/@rpath"; }' EXIT
+	    ln -fs "\$CONDA_DEFAULT_ENV/lib" @rpath
+	fi
+
+	PRODUCT="$PRODUCT"
+	EUPS_VERSION="$EUPS_VERSION"
+
+	eupspkg PREFIX="$PREFIX" PRODUCT="$PRODUCT" VERSION="$EUPS_VERSION" FLAVOR=generic "\$@"
+EOT
+chmod +x _build.sh
+
+# configure, build, install, declare to EUPS
+./_build.sh config
+./_build.sh build
+./_build.sh install
+./_build.sh decl
+
+# Add EUPS tags.  The tags will be stored in a file in the product's ups
+# dir; it will be merged by the pre-link.sh script with the EUPS database
+# when the package is installed
+TAGFILE="$EUPS_PATH/ups_db/global.tags"
+for TAG in current conda; do
+	# FIXME: This should be handled by the post-link/pre-delete script !!!
+	test -f "$TAGFILE" && echo -n " " >> "$TAGFILE"
+	echo -n "$TAG" >> "$TAGFILE"
+
+	eups declare -t $TAG "$PRODUCT" "$EUPS_VERSION"
+done
+mv "$TAGFILE" "$PREFIX/ups"
+
+
+############################################################################
+# Binary preparation, directory cleanups
+#
+
+# compile all .py and .cfg files so they don't get picked up as new by conda
+# when building other packages
+if [[ -d "$PREFIX/python" ]]; then
+	# don't fail in case of syntax errors, etc.
+	"$PYTHON" -m compileall "$PREFIX/python" || true
+fi
+if ls "$PREFIX/ups"/*.cfg 1> /dev/null 2>&1; then
+	"$PYTHON" -m py_compile "$PREFIX/ups"/*.cfg
+fi

--- a/etc/recipes/lsst-mariadbclient/meta.yaml
+++ b/etc/recipes/lsst-mariadbclient/meta.yaml
@@ -1,0 +1,36 @@
+#
+# Run `conda build .` to build this package
+#
+
+package:
+  name: "lsst-mariadbclient"
+  version: "0.10.1.11.3"
+
+source:
+  git_rev: "a3cbbea09f2ba4d2a6064595ba8d300c478cab0f"
+  git_url: "https://github.com/LSST/mariadbclient"
+
+
+build:
+  number: 1
+  string: "1"
+#  binary_relocation: false
+
+requirements:
+  build:
+    - eups >=2.0.2
+    - gcc ==4.8.5                   # [not osx]
+    - nomkl                         #
+    - openssl
+    - patchelf ==0.8                # [not osx]
+
+  run:
+    - eups >=2.0.2
+    - libgcc >=4.8.5                # [not osx]
+    - nomkl                         #
+    - openssl
+
+about:
+  home: "https://github.com/LSST/mariadbclient"
+#  license: GPLv2
+#  summary: A version manager tracking product dependencies

--- a/etc/recipes/lsst-mariadbclient/pre-link.sh
+++ b/etc/recipes/lsst-mariadbclient/pre-link.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Fail immediately if something's wrong
+set -e
+
+# Write into this file for anything that the user should see
+OUT="$PREFIX/.messages.txt"
+
+# Adjust SOURCE_DIR (for convenience)
+SOURCE_DIR="$SOURCE_DIR/opt/lsst/mariadbclient"
+
+# Add $PREFIX/bin to $PATH; it's not on the path when run
+# in _build environment (is this a bug in conda-build?)
+export PATH="$PREFIX/bin:$PATH"
+
+# initialize EUPS
+source eups-setups.sh
+
+# Merge the EUPS tags used by this package with the global EUPS database
+#
+IFS=':' read -ra EUPS_PATH_ARR <<< "$EUPS_PATH"
+TAGFILE="${EUPS_PATH_ARR[0]}/ups_db/global.tags"
+
+# We need to merge the tags in the existing global.tags file, with any new
+# tags that our product needs:
+#
+# What the magic below does (in order):
+#   * cat both files, ensuring there's a newline between them
+#   * convert whitespaces to newlines
+#   * sort & run uniq
+#   * remove any empty lines
+#   * translate newlines back to whitespaces
+touch "$TAGFILE"						# make sure it exists
+awk 'FNR==1{print ""}1' "$SOURCE_DIR/ups/global.tags" "$TAGFILE" | 	\
+		tr ' ' '\n' | \
+		sort -u     | \
+		awk 'NF'    | \
+		tr '\n' ' ' \
+		> "$TAGFILE".tmp
+
+# Move the new file into place
+mv "$TAGFILE".tmp "$TAGFILE"


### PR DESCRIPTION
Configure mariadb and mariadbclient to build on Mac OS X.
- Use the platform's cmake since Conda's version is old.
- Set MACOSX_DEPLOYMENT_TARGET="" and CMAKE_OSX_SYSROOT="/" so
   the the package will build.
- Add support to preemptively use etc/recipes.
  - Add prefer_etc_recipes to config.
  - Implement support for prefer_etc_recipes to recipe_make.RecipeMaker.
  - Support root_dir in config.Config.
    
    ```
    modified:   conda_lsst/config.py
    modified:   conda_lsst/recipe_maker.py
    modified:   etc/config.yaml
    new file:   etc/recipes/lsst-mariadbclient/build.sh
    new file:   etc/recipes/lsst-mariadbclient/meta.yaml
    new file:   etc/recipes/lsst-mariadbclient/pre-link.sh
    new file:   etc/recipes/lsst-mariadb/build.sh
    new file:   etc/recipes/lsst-mariadb/meta.yaml
    new file:   etc/recipes/lsst-mariadb/pre-link.sh
    ```
