### PR TITLE
pin numpy to 1.9.2

### DIFF
--- a/etc/config.yaml
+++ b/etc/config.yaml
@@ -157,8 +157,8 @@ dependencies:
 #
 pin_versions:
   numpy:
-    build: "==1.9"
-    run:   ">=1.9"
+    build: "==1.9.2"
+    run:   ">=1.9.2"
   python:
     build: "2.7.*"
     run:   "2.7.*"


### PR DESCRIPTION
The conda numpy 1.9.0 package is missing the dep on libgfortran.so.1.
See: https://github.com/conda/conda/issues/444

```
Setting up environment to build package 'utils'.
Ignoring prefix /home/conda/conda-lsst/miniconda/envs/_build/var/opt/eups/Linux64/uti
ls/12.1.rc1+1 from EUPS_PATH
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/conda/conda-lsst/miniconda/envs/_build/lib/python2.7/site-packages/nump
y/__init__.py", line 170, in <module>
from . import add_newdocs
  File "/home/conda/conda-lsst/miniconda/envs/_build/lib/python2.7/site-packages/nump
y/add_newdocs.py", line 13, in <module>
from numpy.lib import add_newdoc
  File "/home/conda/conda-lsst/miniconda/envs/_build/lib/python2.7/site-packages/numpy/lib/__init__.py", line 18, in <module>
from .polynomial import *
  File "/home/conda/conda-lsst/miniconda/envs/_build/lib/python2.7/site-packages/numpy/lib/polynomial.py", line 19, in <module>
from numpy.linalg import eigvals, lstsq, inv
  File "/home/conda/conda-lsst/miniconda/envs/_build/lib/python2.7/site-packages/numpy/linalg/__init__.py", line 51, in <module>
from .linalg import *
  File "/home/conda/conda-lsst/miniconda/envs/_build/lib/python2.7/site-packages/numpy/linalg/linalg.py", line 29, in <module>
from numpy.linalg import lapack_lite, _umath_linalg
ImportError: libgfortran.so.1: cannot open shared object file: No such file or directory
```
