### PR TITLE
[DM-7666] conda-lsst broken with conda >= 4.2.6.

### DIFF
--- a/conda_lsst/config.py
+++ b/conda_lsst/config.py
@@ -309,7 +309,7 @@ def _get_our_channels(regex):
 	from urlparse import urljoin
 	import conda.config
 
-	chans = [ urljoin(conda.config.channel_alias, u).rstrip('/ ') + '/' for u in conda.config.get_rc_urls() ]
+	chans = [ urljoin(conda.config.context.channel_alias, u).rstrip('/ ') + '/' for u in conda.config.get_rc_urls() ]
 	chans = [ chan for chan in chans if re.match(regex, chan) ]
 	return chans
 


### PR DESCRIPTION
This breaks conda-lsst when using the current stable conda version. Conda moved the channel_alias field from config to config.context.

```
modified:   conda_lsst/config.py
```
