### PR TITLE
[DM-8072] conda-lsst broken with current Conda.

### DIFF
--- a/conda_lsst/config.py
+++ b/conda_lsst/config.py
@@ -309,7 +309,7 @@ def _get_our_channels(regex):
 	from urlparse import urljoin
 	import conda.config
 
-	chans = [ urljoin(conda.config.channel_alias, u).rstrip('/ ') + '/' for u in conda.config.get_rc_urls() ]
+	chans = [ urljoin(str(conda.config.channel_alias), u).rstrip('/ ') + '/' for u in conda.config.get_rc_urls() ]
 	chans = [ chan for chan in chans if re.match(regex, chan) ]
 	return chans
 


### PR DESCRIPTION
The conda-lsst is broken using the current Conda version.

channel_alias used to implicitly cast to a str now it needs to be done explicitly.

```
modified:   conda_lsst/config.py
```
