### PR TITLE
[DM-7977] Build Dockerfile using ContinuumIO's Conda build image.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,34 +1,32 @@
-FROM    centos:centos5
+FROM continuumio/centos5_gcc5_base:5.11-5.2-1
+MAINTAINER J. Matt Peterson <jmatt@lsst.org>
 
-# Following instructions on:
-# https://www.digitalocean.com/community/tutorials/docker-explained-using-dockerfiles-to-automate-building-of-images
+WORKDIR /build
+COPY build/yum_install_syslibs.sh \
+     build/yum_install_cmake28.sh \
+     build/source_install_git.sh \
+     build/install_jmatt_lsstsw.sh \
+     build/install_jmatt_conda-lsst.sh \
+     build/yum_install_tools.sh \
+     build/git-2.2.2.tar.gz \
+     /build/
 
-# Get toolchain prerequisites
-RUN	yum install -y \
-		curl git \
-		make glibc-headers glibc-devel patch bzip2 libgfortran bzip2-devel \
-		flex bison which ncurses-devel zlib-devel which \
-		libXext libSM libXrender \
-		readline-devel
+RUN yum install -y epel-release bash
 
-# fftw's eupspkg.cfg.sh gratuitously requires rsync
-RUN	yum install -y rsync
+RUN bash yum_install_syslibs.sh && \
+    bash yum_install_cmake28.sh
 
-# Install joe for mjuric
-RUN	rpm -ivh http://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm && \
-	yum install -y joe
+RUN bash source_install_git.sh
 
-# Create user corresponding to our local user
-ARG	GROUP_ID
-ARG	GROUP_NAME
-ARG	USER_ID
-ARG	USER_NAME
-ARG	HOME
+RUN bash install_jmatt_lsstsw.sh && \
+    bash install_jmatt_conda-lsst.sh
 
-RUN	groupadd -g $GROUP_ID $GROUP_NAME
-RUN	useradd -d $HOME -g $GROUP_NAME -u $USER_ID $USER_NAME
+RUN bash yum_install_tools.sh && \
+    rm -rf /build/ && \
+    useradd -m --uid 1000 -G wheel dev && \
+    echo '%wheel ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
+    echo 'Defaults:%wheel !requiretty' >> /etc/sudoers && \
+    chown -R dev:dev /opt
 
-ENV	PATH=$HOME/conda-lsst/miniconda/bin:$PATH
-
-USER	$USER_ID
-WORKDIR	$HOME
+WORKDIR /home/dev
+USER dev

--- a/docker/build/install_jmatt_conda-lsst.sh
+++ b/docker/build/install_jmatt_conda-lsst.sh
@@ -1,0 +1,5 @@
+cd /opt
+/usr/bin/git clone https://github.com/jmatt/conda-lsst.git -b v12.1
+cd /opt/conda-lsst
+./bin/bootstrap.sh
+

--- a/docker/build/install_jmatt_lsstsw.sh
+++ b/docker/build/install_jmatt_lsstsw.sh
@@ -1,0 +1,4 @@
+cd /opt
+/usr/bin/git clone https://github.com/jmatt/lsstsw.git
+cd /opt/lsstsw
+./bin/deploy

--- a/docker/build/source_install_git.sh
+++ b/docker/build/source_install_git.sh
@@ -1,0 +1,10 @@
+mkdir -p /opt/build
+cd /opt/build
+cp /build/git-2.2.2.tar.gz /opt/build/
+tar xfvz ./git-2.2.2.tar.gz
+rm ./git-2.2.2.tar.gz
+cd git-2.2.2
+make configure
+./configure --prefix=/usr
+make all
+make install

--- a/docker/build/yum_install_cmake28.sh
+++ b/docker/build/yum_install_cmake28.sh
@@ -1,0 +1,5 @@
+yum install -y cmake28
+ln -s /usr/bin/cmake28 /usr/bin/cmake
+ln -s /usr/bin/ccmake28 /usr/bin/ccmake
+ln -s /usr/bin/cpack28 /usr/bin/cpack
+ln -s /usr/bin/ctest28 /usr/bin/ctest

--- a/docker/build/yum_install_syslibs.sh
+++ b/docker/build/yum_install_syslibs.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+yum install -y epel-release bash
+yum install -y glib2-devel libX11-devel libXext-devel libXrender-devel  \
+    mesa-libGL-devel libICE-devel libSM-devel ncurses-devel \
+    openssh-clients.x86_64 patch.x86_64 dbus-devel gtk2-devel \
+    chrpath.x86_64 nano bzip2 xz sudo wget curl curl-devel expat-devel \
+    gettext-devel openssl-devel perl-devel zlib-devel bzip2-devel \
+    flex rsync

--- a/docker/build/yum_install_tools.sh
+++ b/docker/build/yum_install_tools.sh
@@ -1,0 +1,1 @@
+yum install -y emacs-nox


### PR DESCRIPTION
  * Use ContinuumIO's CentOS5.11 GCC 5.2.0 docker image.
  * Reorganize into individual build scripts. This allows for shorter image build time. This also
     makes the image build more modular for both testing and creation.
  * The git repository was added since retrieving it failed multiple times.
  * This also installs lsstsw to allow users to attempt to reproduce conda-lsst problems in lsstsw.
  * This uses the jmatt fork, v12.1 branch of conda-lsst. Since this was the version used while in
     development.

	modified:   Dockerfile
	new file:   build/git-2.2.2.tar.gz
	new file:   build/install_jmatt_conda-lsst.sh
	new file:   build/install_jmatt_lsstsw.sh
	new file:   build/source_install_git.sh
	new file:   build/yum_install_cmake28.sh
	new file:   build/yum_install_syslibs.sh
	new file:   build/yum_install_tools.sh
