### PR TITLE
[DM-8135] Fixup and complete v12.1 Conda binary packaging.

### DIFF
--- a/etc/config.yaml
+++ b/etc/config.yaml
@@ -13,7 +13,8 @@ git-upstreams:
 # Any SHA1 overrides to be applied to the build manifest
 # This is a list of mapping of 'product_name' -> 'SHA1-or-ref'
 #
-override_gitrev: {}
+override_gitrev: {'mariadbclient': '73b49da5098fb9e3aec157f1df0d3c1748ceea5e',
+                  'mariadb': '65eddaa0fadeab3274af9b3e3769e76ab2854c7b'}
 
 #
 # Directory with patches
@@ -47,6 +48,11 @@ internal_products:
   sqlalchemy:
   requests:
   astropy:
+  cmake:
+  future:
+  pandas:
+  cython:
+  mpi4py:
 
 #
 # EUPS products we should ignore alltogether
@@ -60,6 +66,12 @@ skip_products:
 # Prefix to add to all packages we'll buld
 #
 lsst_prefix: "lsst-"
+
+#
+# Use Conda recipes found in etc/recipes first before using remote
+# git repositories.
+#
+prefer_etc_recipes: yes
 
 #
 # Explicit overrides for mapping of EUPS->conda product names
@@ -91,6 +103,9 @@ dependencies:
   sims_catalogs_generation:
     run:   [ sqlalchemy ]
     build: [ sqlalchemy ]
+  sims-catutils:
+    run:   [ pandas ]
+    build: [ pandas ]
   sims_skybrightness:
     run:   [ sqlalchemy ]
     build: [ sqlalchemy ]
@@ -135,9 +150,12 @@ dependencies:
   sims_movingObjects:
     run:   [ pandas, numexpr ]
     build: [ pandas, numexpr ]
-  oorb:
-    build: [ "gcc ==4.8.5" ]
-    run:   [ "libgcc >=4.8.5" ]
+  ctrl_pool:
+    build: [ "mpi4py" ]
+    run:   [ "mpi4py" ]
+  mpi4py:
+    build: [ "cython" ]
+    run:   [ "cython" ]
   "*":
     run:
       - "nomkl                         # [not osx]"
@@ -146,8 +164,6 @@ dependencies:
     build:
       - "nomkl                         # [not osx]"
       - recipe/eups >=2.0.2
-      - "gcc ==4.8.5                   # [not osx]"
-      - "patchelf ==0.8                # [not osx]"
 
 #
 # Pin a specific version of a package. This will be applied to all
@@ -156,9 +172,12 @@ dependencies:
 # conda packages used as dependencies.
 #
 pin_versions:
+  astropy:
+    build: "1.1.2"
+    run: ">=1.1.2,<1.3"
   numpy:
-    build: "==1.9"
-    run:   ">=1.9"
+    build: "1.10.4"
+    run:   ">=1.10.4,<1.12"
   python:
     build: "2.7.*"
     run:   "2.7.*"
@@ -168,6 +187,9 @@ pin_versions:
   scipy:
     build: "0.16.*"
     run:   ">=0.16"
+  mpi4py:
+    build: "2.0.0"
+    run:   "2.0.0"
 
 #
 # which packages to build on which OS. The effect of this will be to add

--- a/etc/patches/afw/010-rework-testSpatialCell-DM-8029.patch
+++ b/etc/patches/afw/010-rework-testSpatialCell-DM-8029.patch
@@ -1,0 +1,381 @@
+diff --git examples/testSpatialCell.cc examples/testSpatialCell.cc
+index 09ffe0c..712ce75 100644
+--- examples/testSpatialCell.cc
++++ examples/testSpatialCell.cc
+@@ -30,10 +30,10 @@
+ ExampleCandidate::ExampleCandidate(
+         float const xCenter,            ///< The object's column-centre
+         float const yCenter,            ///< The object's row-centre
+-        ExampleCandidate::MaskedImageT::ConstPtr parent, ///< the parent image
++        std::shared_ptr<MaskedImageT const> parent, ///< the parent image
+         lsst::afw::geom::Box2I bbox     ///< The object's bounding box
+                                       ) :
+-    lsst::afw::math::SpatialCellMaskedImageCandidate<PixelT>(xCenter, yCenter), _parent(parent), _bbox(bbox) {
++    lsst::afw::math::SpatialCellImageCandidate(xCenter, yCenter), _parent(parent), _bbox(bbox) {
+ }
+ 
+ /**
+@@ -46,10 +46,9 @@ double ExampleCandidate::getCandidateRating() const {
+ /**
+  * Return the %image
+  */
+-ExampleCandidate::MaskedImageT::ConstPtr ExampleCandidate::getMaskedImage() const {
+-    if (_image.get() == NULL) {
+-        _image = MaskedImageT::Ptr(new MaskedImageT(*_parent, _bbox, lsst::afw::image::LOCAL));
++std::shared_ptr<ExampleCandidate::MaskedImageT const> ExampleCandidate::getMaskedImage() const {
++    if (!_image) {
++        _image = std::make_shared<MaskedImageT>(*_parent, _bbox, lsst::afw::image::LOCAL);
+     }
+-
+     return _image;
+ }
+diff --git examples/testSpatialCell.h examples/testSpatialCell.h
+index d8a7946..460366c 100644
+--- examples/testSpatialCell.h
++++ examples/testSpatialCell.h
+@@ -32,22 +32,23 @@
+ /*
+  * Test class for SpatialCellImageCandidate
+  */
+-class ExampleCandidate : public lsst::afw::math::SpatialCellMaskedImageCandidate<float> {
++class ExampleCandidate : public lsst::afw::math::SpatialCellImageCandidate {
+ public:
+-    typedef std::shared_ptr<ExampleCandidate> Ptr;
+     typedef float PixelT;
+     typedef lsst::afw::image::MaskedImage<PixelT> MaskedImageT;
+ 
+     ExampleCandidate(float const xCenter, float const yCenter,
+-                     MaskedImageT::ConstPtr parent, lsst::afw::geom::Box2I bbox);
++                     std::shared_ptr<MaskedImageT const> parent, lsst::afw::geom::Box2I bbox);
+ 
+     lsst::afw::geom::Box2I getBBox() const { return _bbox; }
+ 
+     double getCandidateRating() const;
+ 
+-    MaskedImageT::ConstPtr getMaskedImage() const;
++    std::shared_ptr<MaskedImageT const> getMaskedImage() const;
++
+ private:
+-    ExampleCandidate::MaskedImageT::ConstPtr _parent;
++    mutable std::shared_ptr<MaskedImageT> _image;
++    std::shared_ptr<MaskedImageT const> _parent;
+     lsst::afw::geom::Box2I _bbox;
+ };
+ 
+diff --git include/lsst/afw/math/SpatialCell.h include/lsst/afw/math/SpatialCell.h
+index e81bb29..f5645ab 100644
+--- include/lsst/afw/math/SpatialCell.h
++++ include/lsst/afw/math/SpatialCell.h
+@@ -129,7 +129,6 @@ namespace math {
+      * Base class for candidate objects in a SpatialCell that are able to return an Image of some sort
+      * (e.g. a PSF or a DIA kernel)
+      */
+-    template<typename PixelT>
+     class SpatialCellImageCandidate : public SpatialCellCandidate {
+     public:
+         typedef std::shared_ptr<SpatialCellImageCandidate> Ptr;
+@@ -139,14 +138,10 @@ namespace math {
+         SpatialCellImageCandidate(float const xCenter, ///< The object's column-centre
+                                   float const yCenter  ///< The object's row-centre
+                                  ) : SpatialCellCandidate(xCenter, yCenter),
+-                                     _image(PTR(lsst::afw::image::Image<PixelT>)()),
+                                      _chi2(std::numeric_limits<double>::max()) {
+         }
+         virtual ~SpatialCellImageCandidate() {}
+ 
+-        /// Return the Candidate's Image
+-        virtual CONST_PTR(lsst::afw::image::Image<PixelT>) getImage() const = 0;
+-
+         /// Set the width of the image that getImage should return
+         static void setWidth(int width) {
+             _width = width;
+@@ -164,81 +159,12 @@ namespace math {
+         /// Set the candidate's chi^2
+         void setChi2(double chi2) { _chi2 = chi2; }
+ 
+-    protected:
+-        PTR(lsst::afw::image::Image<PixelT>) mutable _image; ///< a pointer to the Image, for the use of the base class
+     private:
+         static int _width;              // the width of images to return; may be ignored by subclasses
+         static int _height;             // the height of images to return; may be ignored by subclasses
+         double _chi2;                   // chi^2 for fit
+     };
+ 
+-    /// The width of images that SpatialCellImageCandidate should return; may be ignored by subclasses
+-    template<typename PixelT>
+-    int SpatialCellImageCandidate<PixelT>::_width = 0;
+-
+-    /// The height of images that SpatialCellImageCandidate should return; may be ignored by subclasses
+-    template<typename PixelT>
+-    int SpatialCellImageCandidate<PixelT>::_height = 0;
+-
+-    /************************************************************************************************************/
+-    /**
+-     * Base class for candidate objects in a SpatialCell that are able to return a MaskedImage of some sort
+-     * (e.g. a PSF or a DIA kernel)
+-     */
+-    template<typename PixelT>
+-    class SpatialCellMaskedImageCandidate : public SpatialCellCandidate {
+-    public:
+-        typedef std::shared_ptr<SpatialCellMaskedImageCandidate> Ptr;
+-        typedef std::shared_ptr<const SpatialCellMaskedImageCandidate> ConstPtr;
+-
+-        /// ctor
+-        SpatialCellMaskedImageCandidate(float const xCenter, ///< The object's column-centre
+-                                        float const yCenter  ///< The object's row-centre
+-                                       ) : SpatialCellCandidate(xCenter, yCenter),
+-                                           _image(PTR(lsst::afw::image::MaskedImage<PixelT,
+-                                                      lsst::afw::image::MaskPixel,
+-                                                      lsst::afw::image::VariancePixel>)()),
+-                                           _chi2(std::numeric_limits<double>::max()) {
+-        }
+-        virtual ~SpatialCellMaskedImageCandidate() {}
+-
+-        /// Return the Candidate's Image
+-        virtual CONST_PTR(lsst::afw::image::MaskedImage<PixelT,lsst::afw::image::MaskPixel,
+-                          lsst::afw::image::VariancePixel>) getMaskedImage() const = 0;
+-
+-        /// Set the width of the image that getImage should return
+-        static void setWidth(int width) {
+-            _width = width;
+-        }
+-        /// Return the width of the image that getImage should return
+-        static int getWidth() { return _width; }
+-
+-        /// Set the height of the image that getImage should return
+-        static void setHeight(int height) { _height = height; }
+-        /// Return the height of the image that getImage should return
+-        static int getHeight() { return _height; }
+-
+-        /// Return the candidate's chi^2
+-        double getChi2() const { return _chi2; }
+-        /// Set the candidate's chi^2
+-        void setChi2(double chi2) { _chi2 = chi2; }
+-
+-    protected:
+-        PTR(lsst::afw::image::MaskedImage<PixelT,lsst::afw::image::MaskPixel,
+-            lsst::afw::image::VariancePixel>) mutable _image; ///< a pointer to the MaskedImage, for the use of the base class
+-    private:
+-        static int _width;              // the width of images to return; may be ignored by subclasses
+-        static int _height;             // the height of images to return; may be ignored by subclasses
+-        double _chi2;                   // chi^2 for fit
+-    };
+-
+-    /// The width of images that SpatialCellMaskedImageCandidate should return; may be ignored by subclasses
+-    template<typename PixelT>
+-    int SpatialCellMaskedImageCandidate<PixelT>::_width = 0;
+-
+-    /// The height of images that SpatialCellMaskedImageCandidate should return; may be ignored by subclasses
+-    template<typename PixelT>
+-    int SpatialCellMaskedImageCandidate<PixelT>::_height = 0;
+ 
+     /************************************************************************************************************/
+     /**
+diff --git python/lsst/afw/math/spatialCell.i python/lsst/afw/math/spatialCell.i
+index 8beaf5c..b2c72ed 100644
+--- python/lsst/afw/math/spatialCell.i
++++ python/lsst/afw/math/spatialCell.i
+@@ -22,57 +22,6 @@
+  * see <http://www.lsstcorp.org/LegalNotices/>.
+  */
+ 
+-//
+-// A couple of macros (%IMAGE and %MASKEDIMAGE) to provide MaskedImage's default arguments,
+-// We'll use these to define meta-macros (e.g. %SpatialCellImageCandidatePtr)
+-//
+-%define %IMAGE(PIXTYPE)
+-lsst::afw::image::Image<PIXTYPE>
+-%enddef
+-
+-%define %MASKEDIMAGE(PIXTYPE)
+-lsst::afw::image::MaskedImage<PIXTYPE, lsst::afw::image::MaskPixel, lsst::afw::image::VariancePixel>
+-%enddef
+-
+-//
+-// Must go BEFORE the include
+-//
+-%define %SpatialCellImageCandidatePtrs(TYPE, ...)
+-    %shared_ptr(lsst::afw::math::SpatialCellImageCandidate<TYPE>);
+-    %shared_ptr(lsst::afw::math::SpatialCellMaskedImageCandidate<TYPE>);
+-%enddef
+-//
+-// Must go AFTER the include
+-//
+-%define %SpatialCellImageCandidates(NAME, TYPE)
+-    %template(SpatialCellImageCandidate##NAME) lsst::afw::math::SpatialCellImageCandidate<TYPE>;
+-    %template(SpatialCellMaskedImageCandidate##NAME) lsst::afw::math::SpatialCellMaskedImageCandidate<TYPE>;
+-
+-    //--------------------------------------------------------
+-    // THESE CASTS NOW DEPRECATED IN FAVOR OF %castShared
+-    %inline %{
+-        std::shared_ptr<lsst::afw::math::SpatialCellImageCandidate<TYPE> >
+-        cast_SpatialCellImageCandidate##NAME(std::shared_ptr<lsst::afw::math::SpatialCellCandidate> candidate) {
+-            return std::dynamic_pointer_cast<lsst::afw::math::SpatialCellImageCandidate<TYPE> >(candidate);
+-        }
+-
+-        std::shared_ptr<lsst::afw::math::SpatialCellMaskedImageCandidate<TYPE> >
+-        cast_SpatialCellMaskedImageCandidate##NAME(std::shared_ptr<lsst::afw::math::SpatialCellCandidate> candidate) {
+-             return std::dynamic_pointer_cast<lsst::afw::math::SpatialCellMaskedImageCandidate<TYPE> >(candidate);
+-        }
+-    %}
+-    //--------------------------------------------------------
+-
+-    %castShared(lsst::afw::math::SpatialCellImageCandidate<TYPE>, lsst::afw::math::SpatialCellCandidate)
+-    %castShared(lsst::afw::math::SpatialCellMaskedImageCandidate<TYPE>, lsst::afw::math::SpatialCellCandidate)
+-
+-%enddef
+-
+-//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+-//
+-// OK, now we'll generate some code
+-//
+-
+ %{
+ #include <memory>
+ #include "lsst/afw/math/SpatialCell.h"
+@@ -80,11 +29,9 @@ lsst::afw::image::MaskedImage<PIXTYPE, lsst::afw::image::MaskPixel, lsst::afw::i
+ 
+ %shared_ptr(lsst::afw::math::CandidateVisitor)
+ %shared_ptr(lsst::afw::math::SpatialCellCandidate);
++%shared_ptr(lsst::afw::math::SpatialCellImageCandidate);
+ %shared_ptr(lsst::afw::math::SpatialCell);
+ 
+-%SpatialCellImageCandidatePtrs(float);
+-%SpatialCellImageCandidatePtrs(double);
+-
+ %rename(__incr__) lsst::afw::math::SpatialCellCandidateIterator::operator++;
+ %rename(__deref__) lsst::afw::math::SpatialCellCandidateIterator::operator*;
+ %rename(__eq__) lsst::afw::math::SpatialCellCandidateIterator::operator==;
+@@ -95,10 +42,6 @@ lsst::afw::image::MaskedImage<PIXTYPE, lsst::afw::image::MaskPixel, lsst::afw::i
+ %template(SpatialCellCandidateList) std::vector<std::shared_ptr<lsst::afw::math::SpatialCellCandidate> >;
+ %template(SpatialCellList) std::vector<std::shared_ptr<lsst::afw::math::SpatialCell> >;
+ 
+-%SpatialCellImageCandidates(F, float);
+-%SpatialCellImageCandidates(D, double);
+-
+-
+ %extend lsst::afw::math::SpatialCell {
+     %pythoncode %{
+         def __getitem__(self, ind):
+@@ -121,3 +64,5 @@ lsst::afw::image::MaskedImage<PIXTYPE, lsst::afw::image::MaskPixel, lsst::afw::i
+             self.__incr__()
+     %}
+ }
++
++%castShared(lsst::afw::math::SpatialCellImageCandidate, lsst::afw::math::SpatialCellCandidate)
+\ No newline at end of file
+diff --git src/math/SpatialCell.cc src/math/SpatialCell.cc
+index a196b24..8ba4de9 100644
+--- src/math/SpatialCell.cc
++++ src/math/SpatialCell.cc
+@@ -73,6 +73,10 @@ void SpatialCellCandidate::setStatus(Status status) {
+                       (boost::format("Saw unknown status %d") % status).str());
+ }
+ 
++int SpatialCellImageCandidate::_width = 0;
++
++int SpatialCellImageCandidate::_height = 0;
++
+ /************************************************************************************************************/
+ /**
+  * Ctor
+diff --git tests/testLib.i tests/testLib.i
+index b5badef..1812a57 100644
+--- tests/testLib.i
++++ tests/testLib.i
+@@ -52,7 +52,7 @@ Various swigged-up C++ classes for testing
+ 
+ %shared_ptr(TestCandidate);
+ %shared_ptr(TestCandidateVisitor);
+-%shared_ptr(TestMaskedImageCandidate);
++%shared_ptr(TestImageCandidate);
+ 
+ %inline %{
+     /*
+@@ -96,19 +96,19 @@ Various swigged-up C++ classes for testing
+         int _n;                         // number of TestCandidates
+     };
+ 
+-    /************************************************************************************************************/
++    /*******************************************************************************************************/
+     /*
+-     * Test class for SpatialCellMaskedImageCandidate
++     * Test class for SpatialCellImageCandidate
+      */
+-    class TestMaskedImageCandidate : public lsst::afw::math::SpatialCellMaskedImageCandidate<float> {
++    class TestImageCandidate : public lsst::afw::math::SpatialCellImageCandidate {
+     public:
+         typedef lsst::afw::image::MaskedImage<float> MaskedImageT;
+ 
+-        TestMaskedImageCandidate(float const xCenter, ///< The object's column-centre
+-                                 float const yCenter, ///< The object's row-centre
+-                                 float const flux     ///< The object's flux
+-                                ) :
+-            lsst::afw::math::SpatialCellMaskedImageCandidate<float>(xCenter, yCenter), _flux(flux) {
++        TestImageCandidate(float const xCenter, ///< The object's column-centre
++                           float const yCenter, ///< The object's row-centre
++                           float const flux     ///< The object's flux
++                           ) :
++            lsst::afw::math::SpatialCellImageCandidate(xCenter, yCenter), _flux(flux) {
+         }
+ 
+         /// Return candidates rating
+@@ -117,15 +117,18 @@ Various swigged-up C++ classes for testing
+         }
+ 
+         /// Return the %image
+-        MaskedImageT::ConstPtr getMaskedImage() const {
+-            if (_image.get() == NULL) {
+-                _image = MaskedImageT::Ptr(new MaskedImageT(lsst::afw::geom::ExtentI(getWidth(), getHeight())));
++        std::shared_ptr<MaskedImageT const> getMaskedImage() const {
++            if (!_image) {
++                _image = std::make_shared<MaskedImageT>(lsst::afw::geom::ExtentI(getWidth(), getHeight()));
+                 *_image->getImage() = _flux;
+             }
+-
+             return _image;
+         }
++
+     private:
++        mutable std::shared_ptr<MaskedImageT> _image;
+         double _flux;
+     };
+ %}
++
++%castShared(TestImageCandidate, lsst::afw::math::SpatialCellCandidate)
+\ No newline at end of file
+diff --git tests/testSpatialCell.py tests/testSpatialCell.py
+index 5fe5893..72b5fdb 100755
+--- tests/testSpatialCell.py
++++ tests/testSpatialCell.py
+@@ -288,8 +288,8 @@ def sortKey(a):
+                          [cand.getCandidateRating() for cand in cell1])
+ 
+ 
+-class TestMaskedImageCandidateCase(unittest.TestCase):
+-    """A test case for TestMaskedImageCandidate"""
++class TestImageCandidateCase(unittest.TestCase):
++    """A test case for TestImageCandidate"""
+ 
+     def setUp(self):
+         self.cellSet = afwMath.SpatialCellSet(afwGeom.Box2I(
+@@ -302,16 +302,16 @@ def testInsertCandidate(self):
+         """Test that we can use SpatialCellMaskedImageCandidate"""
+ 
+         flux = 10
+-        self.cellSet.insertCandidate(testLib.TestMaskedImageCandidate(0, 0, flux))
++        self.cellSet.insertCandidate(testLib.TestImageCandidate(0, 0, flux))
+ 
+         cand = self.cellSet.getCellList()[0][0]
+         #
+-        # Swig doesn't know that we're a SpatialCellMaskedImageCandidate;  all it knows is that we have
++        # Swig doesn't know that we're a SpatialCellImageCandidate;  all it knows is that we have
+         # a SpatialCellCandidate, and SpatialCellCandidates don't know about getMaskedImage;  so cast the
+         # pointer to SpatialCellMaskedImageCandidate<Image<float> > and all will be well;
+         #
+ 
+-        cand = afwMath.SpatialCellMaskedImageCandidateF.cast(cand)
++        cand = testLib.TestImageCandidate.cast(cand)
+ 
+         width, height = 15, 21
+         cand.setWidth(width)

--- a/etc/patches/afw/020-remove-testSpatialCell.py.orig-DM-8029.patch
+++ b/etc/patches/afw/020-remove-testSpatialCell.py.orig-DM-8029.patch
@@ -1,0 +1,346 @@
+diff -ru -N tests/testSpatialCell.py.orig tests/testSpatialCell.py.orig
+--- tests/testSpatialCell.py.orig
++++ /dev/null
+@@ -1,342 +0,0 @@
+-#!/usr/bin/env python
+-from __future__ import absolute_import, division
+-from __future__ import print_function
+-from builtins import range
+-
+-#
+-# LSST Data Management System
+-# Copyright 2008, 2009, 2010 LSST Corporation.
+-#
+-# This product includes software developed by the
+-# LSST Project (http://www.lsst.org/).
+-#
+-# This program is free software: you can redistribute it and/or modify
+-# it under the terms of the GNU General Public License as published by
+-# the Free Software Foundation, either version 3 of the License, or
+-# (at your option) any later version.
+-#
+-# This program is distributed in the hope that it will be useful,
+-# but WITHOUT ANY WARRANTY; without even the implied warranty of
+-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-# GNU General Public License for more details.
+-#
+-# You should have received a copy of the LSST License Statement and
+-# the GNU General Public License along with this program.  If not,
+-# see <http://www.lsstcorp.org/LegalNotices/>.
+-#
+-
+-"""
+-Tests for SpatialCell
+-
+-Run with:
+-   python SpatialCell.py
+-or
+-   python
+-   >>> import SpatialCell; SpatialCell.run()
+-"""
+-import unittest
+-
+-import lsst.utils.tests
+-import lsst.pex.exceptions as pexExcept
+-import lsst.afw.math as afwMath
+-import lsst.afw.geom as afwGeom
+-
+-import testLib
+-
+-
+-def getFlux(x):
+-    return 1000 - 10*x
+-
+-#-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+-
+-
+-class SpatialCellTestCase(unittest.TestCase):
+-    """A test case for SpatialCell"""
+-
+-    def setUp(self):
+-        candidateList = afwMath.SpatialCellCandidateList()
+-        self.nCandidate = 5
+-        for i in (0, 1, 4, 3, 2):       # must be all numbers in range(self.nCandidate)
+-            x, y = i, 5*i
+-            candidateList.append(testLib.TestCandidate(x, y, getFlux(x)))
+-
+-        self.cell = afwMath.SpatialCell("Test", afwGeom.Box2I(), candidateList)
+-        self.assertEqual(self.cell.getLabel(), "Test")
+-
+-    def tearDown(self):
+-        del self.cell
+-
+-    def testCandidateList(self):
+-        """Check that we can retrieve candidates, and that they are sorted by ranking"""
+-        self.assertEqual(self.cell[0].getXCenter(), 0)
+-        self.assertEqual(self.cell[1].getXCenter(), 1)
+-        self.assertEqual(self.cell[1].getYCenter(), 5)
+-
+-    def testBuildCandidateListByInsertion(self):
+-        """Build a candidate list by inserting candidates"""
+-
+-        self.cell = afwMath.SpatialCell("Test", afwGeom.Box2I())
+-
+-        for x, y in ([5, 0], [1, 1], [2, 2], [0, 0], [4, 4], [3, 4]):
+-            self.cell.insertCandidate(testLib.TestCandidate(x, y, getFlux(x)))
+-
+-        self.assertEqual(self.cell[0].getXCenter(), 0)
+-
+-    def testIterators(self):
+-        """Test the SpatialCell iterators"""
+-
+-        #
+-        # Count the candidates
+-        #
+-        self.assertEqual(self.cell.size(), self.nCandidate)
+-        self.assertEqual(self.cell.end() - self.cell.begin(), self.nCandidate)
+-
+-        ptr = self.cell.begin()
+-        ptr.__incr__()
+-        self.assertEqual(self.cell.end() - ptr, self.nCandidate - 1)
+-
+-        self.assertEqual(ptr - self.cell.begin(), 1)
+-        #
+-        # Now label one candidate as bad
+-        #
+-        self.cell[2].setStatus(afwMath.SpatialCellCandidate.BAD)
+-
+-        self.assertEqual(self.cell.size(), self.nCandidate - 1)
+-        self.assertEqual(self.cell.end() - self.cell.begin(), self.nCandidate - 1)
+-
+-        self.cell.setIgnoreBad(False)
+-        self.assertEqual(self.cell.size(), self.nCandidate)
+-        self.assertEqual(self.cell.end() - self.cell.begin(), self.nCandidate)
+-
+-    def testGetCandidateById(self):
+-        """Check that we can lookup candidates by ID"""
+-        id = self.cell[1].getId()
+-        self.assertEqual(self.cell.getCandidateById(id).getId(), id)
+-
+-        self.assertEqual(self.cell.getCandidateById(-1, True), None)
+-        with self.assertRaises(pexExcept.NotFoundError):
+-            self.cell.getCandidateById(-1)
+-
+-    def testSetIteratorBad(self):
+-        """Setting a candidate BAD shouldn't stop us seeing the rest of the candidates"""
+-        i = 0
+-        for cand in self.cell:
+-            if i == 1:
+-                cand.setStatus(afwMath.SpatialCellCandidate.BAD)
+-            i += 1
+-
+-        self.assertEqual(i, self.nCandidate)
+-
+-    def testSortCandidates(self):
+-        """Check that we can update ratings and maintain order"""
+-        ratings0 = [cand.getCandidateRating() for cand in self.cell]
+-        #
+-        # Change a rating
+-        #
+-        i, flux = 1, 9999
+-        self.cell[i].setCandidateRating(flux)
+-        ratings0[i] = flux
+-
+-        self.assertEqual(ratings0, [cand.getCandidateRating() for cand in self.cell])
+-
+-        self.cell.sortCandidates()
+-        self.assertNotEqual(ratings0, [cand.getCandidateRating() for cand in self.cell])
+-        def sortKey(a):
+-            return -a
+-        self.assertEqual(sorted(ratings0, key=sortKey),
+-                         [cand.getCandidateRating() for cand in self.cell])
+-
+-#-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+-
+-
+-class SpatialCellSetTestCase(unittest.TestCase):
+-    """A test case for SpatialCellSet"""
+-
+-    def setUp(self):
+-        self.cellSet = afwMath.SpatialCellSet(afwGeom.Box2I(
+-            afwGeom.Point2I(0, 0), afwGeom.Extent2I(501, 501)), 260, 200)
+-
+-    def makeTestCandidateCellSet(self):
+-        """Populate a SpatialCellSet"""
+-
+-        if False:                       # Print the bboxes for the cells
+-            print()
+-            for i in range(len(self.cellSet.getCellList())):
+-                cell = self.cellSet.getCellList()[i]
+-                print(i, "%3d,%3d -- %3d,%3d" % (cell.getBBox().getMinX(), cell.getBBox().getMinY(),
+-                                                 cell.getBBox().getMaxX(), cell.getBBox().getMaxY()),
+-                      cell.getLabel())
+-        self.assertEqual(len(self.cellSet.getCellList()), 6)
+-
+-        self.NTestCandidates = 0                                      # number of candidates
+-        for x, y in ([5, 0], [1, 1], [2, 2], [0, 0], [4, 4], [3, 4]):  # all in cell0
+-            self.cellSet.insertCandidate(testLib.TestCandidate(x, y, -x))
+-            self.NTestCandidates += 1
+-
+-        self.cellSet.insertCandidate(testLib.TestCandidate(305, 0, 100))   # in cell1
+-        self.NTestCandidates += 1
+-        self.cellSet.insertCandidate(testLib.TestCandidate(500, 500, 100))  # the top right corner of cell5
+-        self.NTestCandidates += 1
+-
+-    def tearDown(self):
+-        del self.cellSet
+-
+-    def testNoCells(self):
+-        """Test that we check for a request to make a SpatialCellSet with no cells"""
+-        def tst():
+-            afwMath.SpatialCellSet(afwGeom.Box2I(afwGeom.Point2I(0, 0), afwGeom.Extent2I(500, 500)), 0, 3)
+-
+-        self.assertRaises(pexExcept.LengthError, tst)
+-
+-    def testInsertCandidate(self):
+-        """Insert candidates into the SpatialCellSet"""
+-
+-        self.makeTestCandidateCellSet()
+-
+-        def tst():
+-            self.cellSet.insertCandidate(testLib.TestCandidate(501, 501, 100))      # Doesn't fit
+-        self.assertRaises(pexExcept.OutOfRangeError, tst)
+-        #
+-        # OK, the SpatialCellList is populated
+-        #
+-        cell0 = self.cellSet.getCellList()[0]
+-        self.assertFalse(cell0.empty())
+-        self.assertEqual(cell0[0].getXCenter(), 0.0)
+-
+-        self.assertEqual(self.cellSet.getCellList()[1][0].getXCenter(), 305.0)
+-
+-        self.assertTrue(self.cellSet.getCellList()[2].empty())
+-
+-        def tst1():
+-            self.cellSet.getCellList()[2][0]
+-        self.assertRaises(IndexError, tst1)
+-
+-        def tst2():
+-            self.cellSet.getCellList()[2].begin().__deref__()
+-        self.assertRaises(pexExcept.NotFoundError, tst2)
+-
+-        self.assertFalse(self.cellSet.getCellList()[5].empty())
+-
+-    def testVisitor(self):
+-        """Test the candidate visitors"""
+-
+-        self.makeTestCandidateCellSet()
+-
+-        visitor = testLib.TestCandidateVisitor()
+-
+-        self.cellSet.visitCandidates(visitor)
+-        self.assertEqual(visitor.getN(), self.NTestCandidates)
+-
+-        self.cellSet.visitCandidates(visitor, 1)
+-        self.assertEqual(visitor.getN(), 3)
+-
+-    def testGetCandidateById(self):
+-        """Check that we can lookup candidates by ID"""
+-
+-        self.makeTestCandidateCellSet()
+-        #
+-        # OK, the SpatialCellList is populated
+-        #
+-        id = self.cellSet.getCellList()[0][1].getId()
+-        self.assertEqual(self.cellSet.getCandidateById(id).getId(), id)
+-
+-        def tst():
+-            self.cellSet.getCandidateById(-1)  # non-existent ID
+-
+-        self.assertEqual(self.cellSet.getCandidateById(-1, True), None)
+-        self.assertRaises(pexExcept.NotFoundError, tst)
+-
+-    def testSpatialCell(self):
+-        dx, dy, sx, sy = 100, 100, 50, 50
+-        for x0, y0 in [(0, 0), (100, 100)]:
+-            # only works for tests where dx,dx is some multiple of sx,sy
+-            assert(dx//sx == float(dx)/float(sx))
+-            assert(dy//sy == float(dy)/float(sy))
+-
+-            bbox = afwGeom.Box2I(afwGeom.Point2I(x0, y0), afwGeom.Extent2I(dx, dy))
+-            cset = afwMath.SpatialCellSet(bbox, sx, sy)
+-            for cell in cset.getCellList():
+-                label = cell.getLabel()
+-                nx, ny = [int(z) for z in label.split()[1].split('x')]
+-
+-                cbbox = cell.getBBox()
+-
+-                self.assertEqual(cbbox.getMinX(), nx*sx + x0)
+-                self.assertEqual(cbbox.getMinY(), ny*sy + y0)
+-                self.assertEqual(cbbox.getMaxX(), (nx+1)*sx + x0 - 1)
+-                self.assertEqual(cbbox.getMaxY(), (ny+1)*sy + y0 - 1)
+-
+-    def testSortCandidates(self):
+-        """Check that we can update ratings and maintain order"""
+-
+-        self.makeTestCandidateCellSet()
+-
+-        cell1 = self.cellSet.getCellList()[0]
+-        self.assertFalse(cell1.empty())
+-
+-        ratings0 = [cand.getCandidateRating() for cand in cell1]
+-        #
+-        # Change a rating
+-        #
+-        i, flux = 1, 9999
+-        cell1[i].setCandidateRating(flux)
+-        ratings0[i] = flux
+-
+-        self.assertEqual(ratings0, [cand.getCandidateRating() for cand in cell1])
+-
+-        self.cellSet.sortCandidates()
+-        self.assertNotEqual(ratings0, [cand.getCandidateRating() for cand in cell1])
+-        def sortKey(a):
+-            return -a
+-        self.assertEqual(sorted(ratings0, key=sortKey),
+-                         [cand.getCandidateRating() for cand in cell1])
+-
+-#-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+-
+-
+-class TestMaskedImageCandidateCase(unittest.TestCase):
+-    """A test case for TestMaskedImageCandidate"""
+-
+-    def setUp(self):
+-        self.cellSet = afwMath.SpatialCellSet(afwGeom.Box2I(
+-            afwGeom.Point2I(0, 0), afwGeom.Extent2I(501, 501)), 2, 3)
+-
+-    def tearDown(self):
+-        del self.cellSet
+-
+-    def testInsertCandidate(self):
+-        """Test that we can use SpatialCellMaskedImageCandidate"""
+-
+-        flux = 10
+-        self.cellSet.insertCandidate(testLib.TestMaskedImageCandidate(0, 0, flux))
+-
+-        cand = self.cellSet.getCellList()[0][0]
+-        #
+-        # Swig doesn't know that we're a SpatialCellMaskedImageCandidate;  all it knows is that we have
+-        # a SpatialCellCandidate, and SpatialCellCandidates don't know about getMaskedImage;  so cast the
+-        # pointer to SpatialCellMaskedImageCandidate<Image<float> > and all will be well;
+-        #
+-
+-        cand = afwMath.SpatialCellMaskedImageCandidateF.cast(cand)
+-
+-        width, height = 15, 21
+-        cand.setWidth(width)
+-        cand.setHeight(height)
+-
+-        im = cand.getMaskedImage().getImage()
+-        self.assertEqual(im.get(0, 0), flux)  # This is how TestMaskedImageCandidate sets its pixels
+-        self.assertEqual(im.getWidth(), width)
+-        self.assertEqual(im.getHeight(), height)
+-
+-#-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+-
+-
+-class TestMemory(lsst.utils.tests.MemoryTestCase):
+-    pass
+-
+-def setup_module(module):
+-    lsst.utils.tests.init()
+-
+-if __name__ == "__main__":
+-    lsst.utils.tests.init()
+-    unittest.main()

--- a/etc/patches/galsim/010-pip-install-future.patch
+++ b/etc/patches/galsim/010-pip-install-future.patch
@@ -1,0 +1,12 @@
+diff --git ups/eupspkg.cfg.sh ups/eupspkg.cfg.sh
+index c2680e3..1421da2 100644
+--- ups/eupspkg.cfg.sh
++++ ups/eupspkg.cfg.sh
+@@ -3,6 +3,7 @@ SCONSFLAGS+=" PREFIX=$PREFIX PYPREFIX=$PREFIX/lib/python"
+ SCONSFLAGS+=" TMV_DIR=$TMV_DIR EXTRA_LIB_PATH=$TMV_DIR/lib EXTRA_INCLUDE_PATH=$TMV_DIR/include"
+ SCONSFLAGS+=" USE_UNKNOWN_VARS=true"
+ export SCONSFLAGS
++pip install future
+ 
+ if [[ $OSTYPE == darwin* ]]; then
+ 	# Add DYLD_LIBRARY_PATH to SCONSFLAGS (deriving it from LSST_LIBRARY_PATH).

--- a/etc/patches/ip_diffim/005-KernelCandidate-changes-DM-8029.patch
+++ b/etc/patches/ip_diffim/005-KernelCandidate-changes-DM-8029.patch
@@ -1,0 +1,252 @@
+diff --git examples/crossCorrelation.py examples/crossCorrelation.py
+index e557b36..b112ff9 100644
+--- examples/crossCorrelation.py
++++ examples/crossCorrelation.py
+@@ -36,7 +36,7 @@ def makeAutoCorrelation(kernelCellSet, spatialKernel, makePlot=False):
+     d2 = []
+ 
+     for i in range(len(candList)):
+-        cand1 = ipDiffim.cast_KernelCandidateF(kernelCellSet.getCandidateById(candList[i]))
++        cand1 = ipDiffim.KernelCandidateF.cast(kernelCellSet.getCandidateById(candList[i]))
+         x1 = cand1.getXCenter()
+         y1 = cand1.getYCenter()
+ 
+@@ -55,7 +55,7 @@ def makeAutoCorrelation(kernelCellSet, spatialKernel, makePlot=False):
+         kVector1 = kImage1.getArray().ravel()
+ 
+         for j in range(i+1, len(candList)):
+-            cand2 = ipDiffim.cast_KernelCandidateF(kernelCellSet.getCandidateById(candList[j]))
++            cand2 = ipDiffim.KernelCandidateF.cast(kernelCellSet.getCandidateById(candList[j]))
+             x2 = cand2.getXCenter()
+             y2 = cand2.getYCenter()
+ 
+diff --git examples/debugSpatialModel.py examples/debugSpatialModel.py
+index 7cd4f16..b642d8d 100644
+--- examples/debugSpatialModel.py
++++ examples/debugSpatialModel.py
+@@ -113,7 +113,7 @@
+     # Inputs
+     for cell in kernelCellSet.getCellList():
+         for cand in cell.begin(False): # False = include bad candidates
+-            cand = ipDiffim.cast_KernelCandidateF(cand)
++            cand = ipDiffim.KernelCandidateF.cast(cand)
+             rchi2 = cand.getChi2()
+ 
+             # No kernels made
+diff --git examples/jackknifeResampleSpatialKernel.py examples/jackknifeResampleSpatialKernel.py
+index b307eb5..e6011b4 100644
+--- examples/jackknifeResampleSpatialKernel.py
++++ examples/jackknifeResampleSpatialKernel.py
+@@ -157,7 +157,7 @@ def setStatus(self, cellSet, cid, value):
+         # cellSet.getCandidateById(id).setStatus(value)
+         for cell in cellSet.getCellList():
+             for cand in cell.begin(False):
+-                cand = ipDiffim.cast_KernelCandidateF(cand)
++                cand = ipDiffim.KernelCandidateF.cast(cand)
+                 if (cand.getId() == cid):
+                     cand.setStatus(value)
+                     return cand
+@@ -172,7 +172,7 @@ def jackknifeResample(self, psfmatch, results):
+         for cell in cellSet.getCellList():
+             print()
+             for cand in cell.begin(False):
+-                cand = ipDiffim.cast_KernelCandidateF(cand)
++                cand = ipDiffim.KernelCandidateF.cast(cand)
+ 
+                 if cand.getStatus() == afwMath.SpatialCellCandidate.GOOD:
+                     goodList.append(cand.getId())
+diff --git python/lsst/ip/diffim/diffimLib.i python/lsst/ip/diffim/diffimLib.i
+index 7f320b4..ec02e2e 100644
+--- python/lsst/ip/diffim/diffimLib.i
++++ python/lsst/ip/diffim/diffimLib.i
+@@ -217,12 +217,6 @@ lsst::afw::image::Image<PIXTYPE>
+ %define %KernelCandidate(NAME, TYPE)
+ %template(KernelCandidate##NAME) lsst::ip::diffim::KernelCandidate<TYPE>;
+ %template(makeKernelCandidate) lsst::ip::diffim::makeKernelCandidate<TYPE>;
+-%inline %{
+-    lsst::ip::diffim::KernelCandidate<TYPE>::Ptr
+-        cast_KernelCandidate##NAME(lsst::afw::math::SpatialCellCandidate::Ptr candidate) {
+-        return std::dynamic_pointer_cast<lsst::ip::diffim::KernelCandidate<TYPE> >(candidate);
+-    }
+-%}
+ %castShared(lsst::ip::diffim::KernelCandidate<TYPE>, lsst::afw::math::SpatialCellImageCandidate);
+ %castShared(lsst::ip::diffim::KernelCandidate<TYPE>, lsst::afw::math::SpatialCellCandidate);
+ %enddef
+diff --git python/lsst/ip/diffim/diffimTools.py python/lsst/ip/diffim/diffimTools.py
+index 30f5745..e401061 100644
+--- python/lsst/ip/diffim/diffimTools.py
++++ python/lsst/ip/diffim/diffimTools.py
+@@ -260,7 +260,7 @@ def writeKernelCellSet(kernelCellSet, psfMatchingKernel, backgroundModel, outdir
+ 
+     for cell in kernelCellSet.getCellList():
+         for cand in cell.begin(False): # False = include bad candidates
+-            cand = diffimLib.cast_KernelCandidateF(cand)
++            cand = diffimLib.KernelCandidateF.cast(cand)
+             if cand.getStatus() == afwMath.SpatialCellCandidate.GOOD:
+                 xCand = int(cand.getXCenter())
+                 yCand = int(cand.getYCenter())
+@@ -421,7 +421,7 @@ def __call__(self, kernelCellSet, log):
+ 
+                     for cell in kernelCellSet.getCellList():
+                         for cand in cell.begin(False): # False = include bad candidates
+-                            cand = diffimLib.cast_KernelCandidateF(cand)
++                            cand = diffimLib.KernelCandidateF.cast(cand)
+                             if cand.getStatus() != afwMath.SpatialCellCandidate.GOOD:
+                                 continue
+                             diffIm = cand.getDifferenceImage(diffimLib.KernelCandidateF.RECENT)
+diff --git python/lsst/ip/diffim/makeRatingVector.py python/lsst/ip/diffim/makeRatingVector.py
+index bfd6c95..30beda4 100644
+--- python/lsst/ip/diffim/makeRatingVector.py
++++ python/lsst/ip/diffim/makeRatingVector.py
+@@ -32,7 +32,7 @@ def makeRatingVector(kernelCellSet, spatialKernel, spatialBg):
+     nBad = 0
+     for cell in kernelCellSet.getCellList():
+         for cand in cell.begin(False): # False = include bad candidates
+-            cand = diffimLib.cast_KernelCandidateF(cand)
++            cand = diffimLib.KernelCandidateF.cast(cand)
+             if cand.getStatus() == afwMath.SpatialCellCandidate.GOOD:
+                 # this has been used for processing
+                 nGood += 1
+diff --git python/lsst/ip/diffim/psfMatch.py python/lsst/ip/diffim/psfMatch.py
+index 10793b1..db4a079 100644
+--- python/lsst/ip/diffim/psfMatch.py
++++ python/lsst/ip/diffim/psfMatch.py
+@@ -743,7 +743,7 @@ def _diagnostic(self, kernelCellSet, spatialSolution, spatialKernel, spatialBg):
+         nTot = 0
+         for cell in kernelCellSet.getCellList():
+             for cand in cell.begin(False): # False = include bad candidates
+-                cand = diffimLib.cast_KernelCandidateF(cand)
++                cand = diffimLib.KernelCandidateF.cast(cand)
+                 nTot += 1
+                 if cand.getStatus() == afwMath.SpatialCellCandidate.GOOD:
+                     nGood += 1
+diff --git python/lsst/ip/diffim/utils.py python/lsst/ip/diffim/utils.py
+index 3707deb..fad35d6 100644
+--- python/lsst/ip/diffim/utils.py
++++ python/lsst/ip/diffim/utils.py
+@@ -80,7 +80,7 @@ def showKernelSpatialCells(maskedIm, kernelCellSet, showChi2=False, symb="o",
+ 
+             goodies = ctypeBad is None
+             for cand in cell.begin(goodies):
+-                cand = diffimLib.cast_KernelCandidateF(cand)
++                cand = diffimLib.KernelCandidateF.cast(cand)
+                 xc, yc = cand.getXCenter() + origin[0], cand.getYCenter() + origin[1]
+                 if cand.getStatus() == afwMath.SpatialCellCandidate.BAD:
+                     color = ctypeBad
+@@ -158,7 +158,7 @@ def showKernelCandidates(kernelCellSet, kernel, background, frame=None, showBadC
+     candidateIndex = 0
+     for cell in kernelCellSet.getCellList():
+         for cand in cell.begin(False): # include bad candidates
+-            cand = diffimLib.cast_KernelCandidateF(cand)
++            cand = diffimLib.KernelCandidateF.cast(cand)
+ 
+             # Original difference image; if does not exist, skip candidate
+             try:
+@@ -293,7 +293,7 @@ def plotKernelSpatialModel(kernel, kernelCellSet, showBadCandidates=True,
+     badAmps = list()
+     for cell in kernelCellSet.getCellList():
+         for cand in cell.begin(False):
+-            cand = diffimLib.cast_KernelCandidateF(cand)
++            cand = diffimLib.KernelCandidateF.cast(cand)
+             if not showBadCandidates and cand.isBad():
+                 continue
+             candCenter = afwGeom.PointD(cand.getXCenter(), cand.getYCenter())
+@@ -505,7 +505,7 @@ def plotPixelResiduals(exposure, warpedTemplateExposure, diffExposure, kernelCel
+             if not (cand.getStatus() == afwMath.SpatialCellCandidate.GOOD):
+                 continue
+ 
+-            cand = diffimLib.cast_KernelCandidateF(cand)
++            cand = diffimLib.KernelCandidateF.cast(cand)
+             diffim = cand.getDifferenceImage(diffimLib.KernelCandidateF.ORIG)
+             orig = cand.getScienceMaskedImage()
+ 
+diff --git tests/testBuildSingleKernelVisitor.py tests/testBuildSingleKernelVisitor.py
+index 8ea7709..4b339cd 100755
+--- tests/testBuildSingleKernelVisitor.py
++++ tests/testBuildSingleKernelVisitor.py
+@@ -257,7 +257,7 @@ def testVisit(self, nCell=3):
+ 
+         for cell in kernelCellSet.getCellList():
+             for cand in cell.begin(False):
+-                cand = ipDiffim.cast_KernelCandidateF(cand)
++                cand = ipDiffim.KernelCandidateF.cast(cand)
+                 self.assertEqual(cand.getStatus(), afwMath.SpatialCellCandidate.GOOD)
+ 
+     def tearDown(self):
+diff --git tests/testCompareToHotpants.py tests/testCompareToHotpants.py
+index 3516af5..f4b1649 100755
+--- tests/testCompareToHotpants.py
++++ tests/testCompareToHotpants.py
+@@ -154,7 +154,7 @@ def testSingleNoVariation(self):
+ 
+         for cell in self.kernelCellSet.getCellList():
+             for cand in cell.begin(False):  # False = include bad candidates
+-                cand = ipDiffim.cast_KernelCandidateF(cand)
++                cand = ipDiffim.KernelCandidateF.cast(cand)
+                 bsikv.processCandidate(cand)
+                 bspkv.processCandidate(cand)
+ 
+@@ -219,7 +219,7 @@ def testFourNoVariation(self):
+ 
+         for cell in self.kernelCellSet.getCellList():
+             for cand in cell.begin(False):  # False = include bad candidates
+-                cand = ipDiffim.cast_KernelCandidateF(cand)
++                cand = ipDiffim.KernelCandidateF.cast(cand)
+                 bsikv.processCandidate(cand)
+                 bspkv.processCandidate(cand)
+ 
+@@ -277,7 +277,7 @@ def testFourKernelVariation(self):
+ 
+         for cell in self.kernelCellSet.getCellList():
+             for cand in cell.begin(False):  # False = include bad candidates
+-                cand = ipDiffim.cast_KernelCandidateF(cand)
++                cand = ipDiffim.KernelCandidateF.cast(cand)
+                 bsikv.processCandidate(cand)
+                 bspkv.processCandidate(cand)
+ 
+@@ -377,7 +377,7 @@ def testFourBgVariation(self):
+ 
+         for cell in self.kernelCellSet.getCellList():
+             for cand in cell.begin(False):  # False = include bad candidates
+-                cand = ipDiffim.cast_KernelCandidateF(cand)
++                cand = ipDiffim.KernelCandidateF.cast(cand)
+                 bsikv.processCandidate(cand)
+                 bspkv.processCandidate(cand)
+ 
+@@ -439,7 +439,7 @@ def testFourVariation(self):
+ 
+         for cell in self.kernelCellSet.getCellList():
+             for cand in cell.begin(False):  # False = include bad candidates
+-                cand = ipDiffim.cast_KernelCandidateF(cand)
++                cand = ipDiffim.KernelCandidateF.cast(cand)
+                 bsikv.processCandidate(cand)
+                 bspkv.processCandidate(cand)
+ 
+diff --git tests/testKernelCandidateAndSolution.py tests/testKernelCandidateAndSolution.py
+index 1c708dd..bf6c340 100755
+--- tests/testKernelCandidateAndSolution.py
++++ tests/testKernelCandidateAndSolution.py
+@@ -492,7 +492,7 @@ def testInsert(self):
+         nSeen = 0
+         for cell in kernelCellSet.getCellList():
+             for cand in cell.begin(True):
+-                cand = ipDiffim.cast_KernelCandidateF(cand)
++                cand = ipDiffim.KernelCandidateF.cast(cand)
+                 self.assertEqual(cand.getStatus(), afwMath.SpatialCellCandidate.GOOD)
+                 nSeen += 1
+         self.assertEqual(nSeen, 1)
+diff --git tests/testSubtractExposures.py tests/testSubtractExposures.py
+index c6abc0c..387b502 100755
+--- tests/testSubtractExposures.py
++++ tests/testSubtractExposures.py
+@@ -213,8 +213,8 @@ def runXY0(self, poly, fitForBackground=False):
+                 if cand1.getStatus() == afwMath.SpatialCellCandidate.BAD:
+                     continue
+ 
+-                cand1 = ipDiffim.cast_KernelCandidateF(cand1)
+-                cand2 = ipDiffim.cast_KernelCandidateF(kernelCellSet2.getCandidateById(cand1.getId()+count))
++                cand1 = ipDiffim.KernelCandidateF.cast(cand1)
++                cand2 = ipDiffim.KernelCandidateF.cast(kernelCellSet2.getCandidateById(cand1.getId()+count))
+ 
+                 # positions are nearly the same (different at the 0.01 pixel level)
+                 self.assertAlmostEqual(cand1.getXCenter(), cand2.getXCenter(), delta=1e-1)

--- a/etc/patches/ip_diffim/010-SpatialCell-changes-DM-8029.patch
+++ b/etc/patches/ip_diffim/010-SpatialCell-changes-DM-8029.patch
@@ -1,0 +1,59 @@
+diff --git include/lsst/ip/diffim/KernelCandidate.h include/lsst/ip/diffim/KernelCandidate.h
+index 767e644..e8df2cc 100644
+--- include/lsst/ip/diffim/KernelCandidate.h
++++ include/lsst/ip/diffim/KernelCandidate.h
+@@ -35,15 +35,10 @@ namespace diffim {
+      * @ingroup ip_diffim
+      */
+     template <typename _PixelT>
+-    class KernelCandidate :
+-        public afw::math::SpatialCellImageCandidate<afw::math::Kernel::Pixel> {
++    class KernelCandidate : public afw::math::SpatialCellImageCandidate {
+     public:
+         typedef afw::image::Image<afw::math::Kernel::Pixel> ImageT;
+         typedef _PixelT PixelT;         // _after_ afw::math::Kernel::Pixel
+-
+-    private:
+-        using afw::math::SpatialCellImageCandidate<afw::math::Kernel::Pixel>::_image;
+-
+     public:
+         typedef std::shared_ptr<KernelCandidate> Ptr;
+         typedef std::shared_ptr<afw::image::MaskedImage<PixelT> > MaskedImagePtr;
+diff --git python/lsst/ip/diffim/diffimLib.i python/lsst/ip/diffim/diffimLib.i
+index 536b3eb..7f320b4 100644
+--- python/lsst/ip/diffim/diffimLib.i
++++ python/lsst/ip/diffim/diffimLib.i
+@@ -223,9 +223,10 @@ lsst::afw::image::Image<PIXTYPE>
+         return std::dynamic_pointer_cast<lsst::ip::diffim::KernelCandidate<TYPE> >(candidate);
+     }
+ %}
++%castShared(lsst::ip::diffim::KernelCandidate<TYPE>, lsst::afw::math::SpatialCellImageCandidate);
++%castShared(lsst::ip::diffim::KernelCandidate<TYPE>, lsst::afw::math::SpatialCellCandidate);
+ %enddef
+ 
+-%include "lsst/ip/diffim/KernelCandidate.h"
+ %KernelCandidatePtr(F, float);
+ 
+ %include "lsst/ip/diffim/KernelCandidate.h"
+diff --git src/KernelCandidate.cc src/KernelCandidate.cc
+index 7d0bc09..fca2c37 100644
+--- src/KernelCandidate.cc
++++ src/KernelCandidate.cc
+@@ -39,7 +39,7 @@ namespace diffim {
+         MaskedImagePtr const& scienceMaskedImage,
+         lsst::pex::policy::Policy const& policy
+         ) :
+-        lsst::afw::math::SpatialCellImageCandidate<lsst::afw::math::Kernel::Pixel>(xCenter, yCenter),
++        lsst::afw::math::SpatialCellImageCandidate(xCenter, yCenter),
+         _templateMaskedImage(templateMaskedImage),
+         _scienceMaskedImage(scienceMaskedImage),
+         _varianceEstimate(),
+@@ -78,7 +78,7 @@ namespace diffim {
+         MaskedImagePtr const& scienceMaskedImage,
+         lsst::pex::policy::Policy const& policy
+         ) :
+-        lsst::afw::math::SpatialCellImageCandidate<lsst::afw::math::Kernel::Pixel>(source->getX(), source->getY()),
++        lsst::afw::math::SpatialCellImageCandidate(source->getX(), source->getY()),
+         _templateMaskedImage(templateMaskedImage),
+         _scienceMaskedImage(scienceMaskedImage),
+         _varianceEstimate(),

--- a/etc/patches/mariadb/010-el5.patch
+++ b/etc/patches/mariadb/010-el5.patch
@@ -1,0 +1,46 @@
+diff --git patches/el5-asm-compat.patch patches/el5-asm-compat.patch
+deleted file mode 100644
+index 1e3f2a7..0000000
+--- patches/el5-asm-compat.patch
++++ /dev/null
+@@ -1,15 +0,0 @@
+-diff -ru mariadb-10.1.9.orig/include/my_context.h mariadb-10.1.9/include/my_context.h
+---- mariadb-10.1.9.orig/include/my_context.h   2015-11-20 17:08:02.000000000 -0800
+-+++ mariadb-10.1.9/include/my_context.h        2016-01-27 00:26:50.000000000 -0800
+-@@ -27,8 +27,10 @@
+- 
+- #ifdef __WIN__
+- #define MY_CONTEXT_USE_WIN32_FIBERS 1
+--#elif defined(__GNUC__) && __GNUC__ >= 3 && defined(__x86_64__) && !defined(__ILP32__)
+-+#elif defined(__clang__)
+- #define MY_CONTEXT_USE_X86_64_GCC_ASM
+-+#elif defined(__GNUC__) && __GNUC__ >= 3 && defined(__x86_64__) && !defined(__ILP32__)
+-+#define MY_CONTEXT_USE_UCONTEXT
+- #elif defined(__GNUC__) && __GNUC__ >= 3 && defined(__i386__)
+- #define MY_CONTEXT_USE_I386_GCC_ASM
+- #elif defined(HAVE_UCONTEXT)
+diff --git ups/eupspkg.cfg.sh ups/eupspkg.cfg.sh
+index 6ce21fb..287b2f3 100644
+--- ups/eupspkg.cfg.sh
++++ ups/eupspkg.cfg.sh
+@@ -21,8 +21,18 @@ config()
+                 # mroonga does not build on EL5 (conda ref platform) and is
+                 # unused by LSST
+                 ARGS+=('-DPLUGIN_MROONGA=NO')
+-                # required to build on EL5
+-                ARGS+=('-DHAVE_CXX_NEW=NO')
++
++                # needed in order to build with gcc 5.x against el5's old libc
++                # see:
++                # https://stackoverflow.com/questions/32325334/error-symbol-pread64-is-already-defined
++                export CFLAGS=-fgnu89-inline
++                export CXXFLAGS=$CFLAGS
++
++                # Weird problems with versioned symbols have been observed on el5.
++                # A *brutal* workaround is disable versioning.  This will break
++                # any binary linked against a typical build of libmysqlclient.so.
++                # https://jira.lsstcorp.org/browse/DM-8035
++                ARGS+=('-DDISABLE_LIBMYSQLCLIENT_SYMBOL_VERSIONING=TRUE')
+             fi
+             ;;
+         Darwin*)

--- a/etc/patches/mariadbclient/010-el5.patch
+++ b/etc/patches/mariadbclient/010-el5.patch
@@ -1,0 +1,46 @@
+diff --git patches/el5-asm-compat.patch patches/el5-asm-compat.patch
+deleted file mode 100644
+index 1e3f2a7..0000000
+--- patches/el5-asm-compat.patch
++++ /dev/null
+@@ -1,15 +0,0 @@
+-diff -ru mariadb-10.1.9.orig/include/my_context.h mariadb-10.1.9/include/my_context.h
+---- mariadb-10.1.9.orig/include/my_context.h   2015-11-20 17:08:02.000000000 -0800
+-+++ mariadb-10.1.9/include/my_context.h        2016-01-27 00:26:50.000000000 -0800
+-@@ -27,8 +27,10 @@
+- 
+- #ifdef __WIN__
+- #define MY_CONTEXT_USE_WIN32_FIBERS 1
+--#elif defined(__GNUC__) && __GNUC__ >= 3 && defined(__x86_64__) && !defined(__ILP32__)
+-+#elif defined(__clang__)
+- #define MY_CONTEXT_USE_X86_64_GCC_ASM
+-+#elif defined(__GNUC__) && __GNUC__ >= 3 && defined(__x86_64__) && !defined(__ILP32__)
+-+#define MY_CONTEXT_USE_UCONTEXT
+- #elif defined(__GNUC__) && __GNUC__ >= 3 && defined(__i386__)
+- #define MY_CONTEXT_USE_I386_GCC_ASM
+- #elif defined(HAVE_UCONTEXT)
+diff --git ups/eupspkg.cfg.sh ups/eupspkg.cfg.sh
+index e0d1868..5d1c4b1 100644
+--- ups/eupspkg.cfg.sh
++++ ups/eupspkg.cfg.sh
+@@ -22,8 +22,18 @@ config()
+                 # mroonga does not build on EL5 (conda ref platform) and is
+                 # unused by LSST
+                 ARGS+=('-DPLUGIN_MROONGA=NO')
+-                # required to build on EL5
+-                ARGS+=('-DHAVE_CXX_NEW=NO')
++
++                # needed in order to build with gcc 5.x against el5's old libc
++                # see:
++                # https://stackoverflow.com/questions/32325334/error-symbol-pread64-is-already-defined
++                export CFLAGS=-fgnu89-inline
++                export CXXFLAGS=$CFLAGS
++
++                # Weird problems with versioned symbols have been observed on el5.
++                # A *brutal* workaround is disable versioning.  This will break
++                # any binary linked against a typical build of libmysqlclient.so.
++                # https://jira.lsstcorp.org/browse/DM-8035
++                ARGS+=('-DDISABLE_LIBMYSQLCLIENT_SYMBOL_VERSIONING=TRUE')
+             fi
+             ;;
+         Darwin*)

--- a/etc/patches/meas_algorithms/010-adapt-to-SpatialCell-changes-DM-8029.patch
+++ b/etc/patches/meas_algorithms/010-adapt-to-SpatialCell-changes-DM-8029.patch
@@ -1,0 +1,271 @@
+diff --git include/lsst/meas/algorithms/PsfCandidate.h include/lsst/meas/algorithms/PsfCandidate.h
+index 3b6c1a5..ac496c2 100644
+--- include/lsst/meas/algorithms/PsfCandidate.h
++++ include/lsst/meas/algorithms/PsfCandidate.h
+@@ -53,13 +53,8 @@ namespace algorithms {
+      * a spatial model to the PSF.
+      */
+     template <typename PixelT>
+-    class PsfCandidate : public lsst::afw::math::SpatialCellMaskedImageCandidate<PixelT> {
+-        using lsst::afw::math::SpatialCellMaskedImageCandidate<PixelT>::_image;
++    class PsfCandidate : public lsst::afw::math::SpatialCellImageCandidate {
+     public:
+-        using lsst::afw::math::SpatialCellMaskedImageCandidate<PixelT>::getXCenter;
+-        using lsst::afw::math::SpatialCellMaskedImageCandidate<PixelT>::getYCenter;
+-        using lsst::afw::math::SpatialCellMaskedImageCandidate<PixelT>::getWidth;
+-        using lsst::afw::math::SpatialCellMaskedImageCandidate<PixelT>::getHeight;
+     
+         typedef std::shared_ptr<PsfCandidate<PixelT> > Ptr;
+         typedef std::shared_ptr<const PsfCandidate<PixelT> > ConstPtr;
+@@ -76,11 +71,11 @@ namespace algorithms {
+             PTR(afw::table::SourceRecord) const& source, ///< The detected Source
+             CONST_PTR(afw::image::Exposure<PixelT>) parentExposure ///< The image wherein lie the Sources
+         ) :
+-            afw::math::SpatialCellMaskedImageCandidate<PixelT>(source->getX(), source->getY()),
++            afw::math::SpatialCellImageCandidate(source->getX(), source->getY()),
+             _parentExposure(parentExposure),
+             _offsetImage(),
+             _source(source),
+-            _haveImage(false),
++            _image(nullptr),
+             _amplitude(0.0), _var(1.0)
+         {}
+         
+@@ -93,17 +88,17 @@ namespace algorithms {
+             double xCenter,    ///< the desired x center
+             double yCenter     ///< the desired y center
+         ) :
+-            afw::math::SpatialCellMaskedImageCandidate<PixelT>(xCenter, yCenter),
++            afw::math::SpatialCellImageCandidate(xCenter, yCenter),
+             _parentExposure(parentExposure),
+             _offsetImage(),
+             _source(source),
+-            _haveImage(false),
++            _image(nullptr),
+             _amplitude(0.0), _var(1.0)
+         {}
+         
+         /// Destructor
+         virtual ~PsfCandidate() {};
+-        
++
+         /**
+          * Return Cell rating
+          * 
+@@ -167,7 +162,7 @@ namespace algorithms {
+         PTR(afw::image::MaskedImage<PixelT>) mutable _offsetImage; // %image offset to put center on a pixel
+         PTR(afw::table::SourceRecord) _source; // the Source itself
+ 
+-        bool mutable _haveImage;                    // do we have an Image to return?
++        mutable std::shared_ptr<afw::image::MaskedImage<PixelT>> _image; // cutout image to return (cached)
+         double _amplitude;                          // best-fit amplitude of current PSF model
+         double _var;                                // variance to use when fitting this candidate
+         static int _border;                         // width of border of ignored pixels around _image
+diff --git python/lsst/meas/algorithms/pcaPsfDeterminer.py python/lsst/meas/algorithms/pcaPsfDeterminer.py
+index 20ecdf8..815066f 100644
+--- python/lsst/meas/algorithms/pcaPsfDeterminer.py
++++ python/lsst/meas/algorithms/pcaPsfDeterminer.py
+@@ -293,7 +293,7 @@ def determinePsf(self, exposure, psfCandidateList, metadata=None, flagKey=None):
+                 stamps = []
+                 for cell in psfCellSet.getCellList():
+                     for cand in cell.begin(not showBadCandidates): # maybe include bad candidates
+-                        cand = algorithmsLib.cast_PsfCandidateF(cand)
++                        cand = algorithmsLib.PsfCandidateF.cast(cand)
+ 
+                         try:
+                             im = cand.getMaskedImage()
+@@ -341,7 +341,7 @@ def determinePsf(self, exposure, psfCandidateList, metadata=None, flagKey=None):
+                 for cell in psfCellSet.getCellList():
+                     awfulCandidates = []
+                     for cand in cell.begin(False): # include bad candidates
+-                        cand = algorithmsLib.cast_PsfCandidateF(cand)
++                        cand = algorithmsLib.PsfCandidateF.cast(cand)
+                         cand.setStatus(afwMath.SpatialCellCandidate.UNKNOWN) # until proven guilty
+                         rchi2 = cand.getChi2()
+                         if not numpy.isfinite(rchi2) or rchi2 <= 0:
+@@ -362,7 +362,7 @@ def determinePsf(self, exposure, psfCandidateList, metadata=None, flagKey=None):
+             badCandidates = list()
+             for cell in psfCellSet.getCellList():
+                 for cand in cell.begin(False): # include bad candidates
+-                    cand = algorithmsLib.cast_PsfCandidateF(cand)
++                    cand = algorithmsLib.PsfCandidateF.cast(cand)
+                     rchi2 = cand.getChi2()  # reduced chi^2 when fitting PSF to candidate
+                     assert rchi2 > 0
+                     if rchi2 > self.config.reducedChi2ForPsfCandidates:
+@@ -394,7 +394,7 @@ def determinePsf(self, exposure, psfCandidateList, metadata=None, flagKey=None):
+             noSpatialKernel = afwMath.cast_LinearCombinationKernel(psf.getKernel())
+             for cell in psfCellSet.getCellList():
+                 for cand in cell.begin(False):
+-                    cand = algorithmsLib.cast_PsfCandidateF(cand)
++                    cand = algorithmsLib.PsfCandidateF.cast(cand)
+                     candCenter = afwGeom.PointD(cand.getXCenter(), cand.getYCenter())
+                     try:
+                         im = cand.getMaskedImage(kernel.getWidth(), kernel.getHeight())
+@@ -585,7 +585,7 @@ def determinePsf(self, exposure, psfCandidateList, metadata=None, flagKey=None):
+                 numAvailStars += 1
+ 
+             for cand in cell.begin(True):  # do ignore BAD stars
+-                cand = algorithmsLib.cast_PsfCandidateF(cand)
++                cand = algorithmsLib.PsfCandidateF.cast(cand)
+                 src = cand.getSource()
+                 if flagKey is not None:
+                     src.set(flagKey, True)
+@@ -619,6 +619,6 @@ def candidatesIter(psfCellSet, ignoreBad=True):
+     """
+     for cell in psfCellSet.getCellList():
+         for cand in cell.begin(ignoreBad):
+-            yield (cell, algorithmsLib.cast_PsfCandidateF(cand))
++            yield (cell, algorithmsLib.PsfCandidateF.cast(cand))
+ 
+ psfDeterminerRegistry.register("pca", PcaPsfDeterminerTask)
+diff --git python/lsst/meas/algorithms/psf.i python/lsst/meas/algorithms/psf.i
+index 2ca4813..38651d8 100644
+--- python/lsst/meas/algorithms/psf.i
++++ python/lsst/meas/algorithms/psf.i
+@@ -46,16 +46,7 @@ lsst::afw::image::MaskedImage<PIXTYPE, lsst::afw::image::MaskPixel, lsst::afw::i
+ %template(PsfCandidate##NAME) lsst::meas::algorithms::PsfCandidate<TYPE>;
+ %template(makePsfCandidate) lsst::meas::algorithms::makePsfCandidate<TYPE>;
+ 
+-//----------------------------------------------------------------------------
+-// THIS CAST INTERFACE NOW DEPRECATED IN FAVOR OF %castShared
+-%inline %{
+-    PTR(lsst::meas::algorithms::PsfCandidate<TYPE>)
+-        cast_PsfCandidate##NAME(PTR(lsst::afw::math::SpatialCellCandidate) candidate) {
+-        return std::dynamic_pointer_cast<lsst::meas::algorithms::PsfCandidate<TYPE> >(candidate);
+-    }
+-%}
+-//----------------------------------------------------------------------------
+-
++%castShared(lsst::meas::algorithms::PsfCandidate<TYPE>, lsst::afw::math::SpatialCellImageCandidate)
+ %castShared(lsst::meas::algorithms::PsfCandidate<TYPE>, lsst::afw::math::SpatialCellCandidate)
+ 
+ %enddef
+diff --git python/lsst/meas/algorithms/utils.py python/lsst/meas/algorithms/utils.py
+index 0347979..bc7a96a 100644
+--- python/lsst/meas/algorithms/utils.py
++++ python/lsst/meas/algorithms/utils.py
+@@ -98,7 +98,7 @@ def showPsfSpatialCells(exposure, psfCellSet, nMaxPerCell=-1, showChi2=False, sh
+                 if nMaxPerCell > 0:
+                     i += 1
+ 
+-                cand = algorithmsLib.cast_PsfCandidateF(cand)
++                cand = algorithmsLib.PsfCandidateF.cast(cand)
+ 
+                 xc, yc = cand.getXCenter() + origin[0], cand.getYCenter() + origin[1]
+ 
+@@ -156,7 +156,7 @@ def showPsfCandidates(exposure, psfCellSet, psf=None, frame=None, normalize=True
+ 
+     for cell in psfCellSet.getCellList():
+         for cand in cell.begin(False): # include bad candidates
+-            cand = algorithmsLib.cast_PsfCandidateF(cand)
++            cand = algorithmsLib.PsfCandidateF.cast(cand)
+ 
+             rchi2 = cand.getChi2()
+             if rchi2 > 1e100:
+@@ -468,7 +468,7 @@ def plotPsfSpatialModel(exposure, psf, psfCellSet, showBadCandidates=True, numSa
+     badAmps = list()
+     for cell in psfCellSet.getCellList():
+         for cand in cell.begin(False):
+-            cand = algorithmsLib.cast_PsfCandidateF(cand)
++            cand = algorithmsLib.PsfCandidateF.cast(cand)
+             if not showBadCandidates and cand.isBad():
+                 continue
+             candCenter = afwGeom.PointD(cand.getXCenter(), cand.getYCenter())
+@@ -831,7 +831,7 @@ def saveSpatialCellSet(psfCellSet, fileName="foo.fits", frame=None):
+     mode = "w"
+     for cell in psfCellSet.getCellList():
+         for cand in cell.begin(False):  # include bad candidates
+-            cand = algorithmsLib.cast_PsfCandidateF(cand)
++            cand = algorithmsLib.PsfCandidateF.cast(cand)
+ 
+             dx = afwImage.positionToIndex(cand.getXCenter(), True)[1]
+             dy = afwImage.positionToIndex(cand.getYCenter(), True)[1]
+diff --git src/PsfCandidate.cc src/PsfCandidate.cc
+index 0b362ba..b54472a 100644
+--- src/PsfCandidate.cc
++++ src/PsfCandidate.cc
+@@ -294,17 +294,9 @@ measAlg::PsfCandidate<PixelT>::extractImage(
+ template <typename PixelT>
+ CONST_PTR(afwImage::MaskedImage<PixelT>)
+ measAlg::PsfCandidate<PixelT>::getMaskedImage(int width, int height) const {
+-
+-
+-    if (_haveImage && (width != _image->getWidth() || height != _image->getHeight())) {
+-        _haveImage = false;
+-    }
+-
+-    if (!_haveImage) {
++    if (!_image || (width != _image->getWidth() || height != _image->getHeight())) {
+         _image = extractImage(width, height);
+-        _haveImage = true;
+     }
+-
+     return _image;
+ }
+ 
+@@ -315,12 +307,9 @@ measAlg::PsfCandidate<PixelT>::getMaskedImage(int width, int height) const {
+  */
+ template <typename PixelT>
+ CONST_PTR(afwImage::MaskedImage<PixelT>) measAlg::PsfCandidate<PixelT>::getMaskedImage() const {
+-
+     int const width = getWidth() == 0 ? _defaultWidth : getWidth();
+     int const height = getHeight() == 0 ? _defaultWidth : getHeight();
+-
+     return getMaskedImage(width, height);
+-
+ }
+ 
+ /**
+diff --git tests/testPsfDetermination.py tests/testPsfDetermination.py
+index ec552c8..97c372a 100755
+--- tests/testPsfDetermination.py
++++ tests/testPsfDetermination.py
+@@ -421,7 +421,7 @@ def testCandidateList(self):
+                 # don't know about getMaskedImage;  so cast the pointer to
+                 # SpatialCellMaskedImageCandidate<float> and all will be well
+                 #
+-                cand = afwMath.cast_SpatialCellMaskedImageCandidateF(cell[0])
++                cand = measAlg.PsfCandidateF.cast(cell[0])
+                 width, height = 29, 25
+                 cand.setWidth(width)
+                 cand.setHeight(height)
+diff --git tests/testPsfIO.py tests/testPsfIO.py
+index 42911c8..32422d9 100755
+--- tests/testPsfIO.py
++++ tests/testPsfIO.py
+@@ -182,7 +182,7 @@ def testGetPcaKernel(self):
+                 i = 0
+                 for cand in cell:
+                     i += 1
+-                    source = algorithms.cast_PsfCandidateF(cand).getSource()
++                    source = algorithms.PsfCandidateF.cast(cand).getSource()
+ 
+                     xc, yc = source.getXAstrom() - self.mi.getX0(), source.getYAstrom() - self.mi.getY0()
+                     if i <= nStarPerCell:
+@@ -238,7 +238,7 @@ def testGetPcaKernel(self):
+                     # it knows is that we have a SpatialCellCandidate, and SpatialCellCandidates
+                     # don't know about getMaskedImage;  so cast the pointer to PsfCandidate
+                     #
+-                    cand = algorithms.cast_PsfCandidateF(cand)
++                    cand = algorithms.PsfCandidateF.cast(cand)
+                     s = cand.getSource()
+ 
+                     im = cand.getMaskedImage()
+@@ -335,12 +335,12 @@ def testCandidateList(self):
+         for cell in self.cellSet.getCellList():
+             for cand in cell:
+                 #
+-                # Swig doesn't know that we inherited from SpatialCellMaskedImageCandidate;  all
+-                # it knows is that we have a SpatialCellCandidate, and SpatialCellCandidates
+-                # don't know about getMaskedImage;  so cast the pointer to
+-                # SpatialCellMaskedImageCandidate<float> and all will be well
++                # Swig doesn't know that we PsfCandidate;  all it knows is
++                # that we have a SpatialCellCandidate, and
++                # SpatialCellCandidates don't know about getMaskedImage;  so
++                # cast the pointer to PsfCandidate<float> and all will be well
+                 #
+-                cand = afwMath.cast_SpatialCellMaskedImageCandidateF(cell[0])
++                cand = algorithms.PsfCandidateF.cast(cell[0])
+                 width, height = 15, 17
+                 cand.setWidth(width)
+                 cand.setHeight(height)

--- a/etc/patches/meas_algorithms/020-remove-orig-files-DM-8029.patch
+++ b/etc/patches/meas_algorithms/020-remove-orig-files-DM-8029.patch
@@ -1,0 +1,931 @@
+diff -ru -N tests/testPsfDetermination.py.orig tests/testPsfDetermination.py.orig
+--- tests/testPsfDetermination.py.orig
++++ tests/testPsfDetermination.py.orig	1970-01-01 00:00:00.000000000 +0000
+@@ -1,485 +0,0 @@
+-#!/usr/bin/env python
+-#
+-# LSST Data Management System
+-#
+-# Copyright 2008-2016  AURA/LSST.
+-#
+-# This product includes software developed by the
+-# LSST Project (http://www.lsst.org/).
+-#
+-# This program is free software: you can redistribute it and/or modify
+-# it under the terms of the GNU General Public License as published by
+-# the Free Software Foundation, either version 3 of the License, or
+-# (at your option) any later version.
+-#
+-# This program is distributed in the hope that it will be useful,
+-# but WITHOUT ANY WARRANTY; without even the implied warranty of
+-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-# GNU General Public License for more details.
+-#
+-# You should have received a copy of the LSST License Statement and
+-# the GNU General Public License along with this program.  If not,
+-# see <https://www.lsstcorp.org/LegalNotices/>.
+-#
+-from __future__ import absolute_import, division, print_function
+-from builtins import zip
+-from builtins import range
+-import math
+-import numpy as np
+-import unittest
+-
+-from lsst.afw.cameraGeom.testUtils import DetectorWrapper
+-import lsst.afw.detection as afwDetection
+-import lsst.afw.geom as afwGeom
+-import lsst.afw.image as afwImage
+-import lsst.afw.math as afwMath
+-import lsst.afw.table as afwTable
+-import lsst.afw.display.utils as displayUtils
+-import lsst.daf.base as dafBase
+-import lsst.meas.algorithms as measAlg
+-import lsst.meas.base as measBase
+-import lsst.pex.logging as logging
+-import lsst.utils.tests
+-
+-
+-try:
+-    type(verbose)
+-    import lsst.afw.display.ds9 as ds9
+-except NameError:
+-    verbose = 0
+-    logging.Trace.setVerbosity("meas.algorithms.Interp", verbose)
+-    logging.Trace.setVerbosity("afw.detection.Psf", verbose)
+-    display = False
+-
+-#-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+-
+-
+-def psfVal(ix, iy, x, y, sigma1, sigma2, b):
+-    """Return the value at (ix, iy) of a double Gaussian
+-       (N(0, sigma1^2) + b*N(0, sigma2^2))/(1 + b)
+-    centered at (x, y)
+-    """
+-    return (math.exp(-0.5*((ix - x)**2 + (iy - y)**2)/sigma1**2) +
+-            b*math.exp(-0.5*((ix - x)**2 + (iy - y)**2)/sigma2**2))/(1 + b)
+-
+-
+-class SpatialModelPsfTestCase(lsst.utils.tests.TestCase):
+-    """A test case for SpatialModelPsf"""
+-
+-    def measure(self, footprintSet, exposure):
+-        """Measure a set of Footprints, returning a SourceCatalog."""
+-        table = afwTable.SourceCatalog(self.schema)
+-        footprintSet.makeSources(table)
+-
+-        # Then run the default SFM task.  Results not checked
+-        self.measureTask.run(table, exposure)
+-
+-        if display:
+-            ds9.mtv(exposure)
+-
+-        return table
+-
+-    def setUp(self):
+-
+-        self.schema = afwTable.SourceTable.makeMinimalSchema()
+-        config = measBase.SingleFrameMeasurementConfig()
+-        config.algorithms.names = ["base_PixelFlags",
+-                                   "base_SdssCentroid",
+-                                   "base_GaussianFlux",
+-                                   "base_SdssShape",
+-                                   "base_CircularApertureFlux",
+-                                   "base_PsfFlux",
+-                                   ]
+-        config.algorithms["base_CircularApertureFlux"].radii = [3.0]
+-        config.slots.centroid = "base_SdssCentroid"
+-        config.slots.psfFlux = "base_PsfFlux"
+-        config.slots.apFlux = "base_CircularApertureFlux_3_0"
+-        config.slots.modelFlux = None
+-        config.slots.instFlux = None
+-        config.slots.calibFlux = None
+-        config.slots.shape = "base_SdssShape"
+-
+-        self.measureTask = measBase.SingleFrameMeasurementTask(self.schema, config=config)
+-
+-        width, height = 110, 301
+-
+-        self.mi = afwImage.MaskedImageF(afwGeom.ExtentI(width, height))
+-        self.mi.set(0)
+-        sd = 3                          # standard deviation of image
+-        self.mi.getVariance().set(sd*sd)
+-        self.mi.getMask().addMaskPlane("DETECTED")
+-
+-        self.FWHM = 5
+-        self.ksize = 31                      # size of desired kernel
+-
+-        sigma1 = 1.75
+-        sigma2 = 2*sigma1
+-
+-        self.exposure = afwImage.makeExposure(self.mi)
+-        self.exposure.setPsf(measAlg.DoubleGaussianPsf(self.ksize, self.ksize,
+-                                                       1.5*sigma1, 1, 0.1))
+-        self.exposure.setDetector(DetectorWrapper().detector)
+-
+-        #
+-        # Make a kernel with the exactly correct basis functions.  Useful for debugging
+-        #
+-        basisKernelList = afwMath.KernelList()
+-        for sigma in (sigma1, sigma2):
+-            basisKernel = afwMath.AnalyticKernel(self.ksize, self.ksize,
+-                                                 afwMath.GaussianFunction2D(sigma, sigma))
+-            basisImage = afwImage.ImageD(basisKernel.getDimensions())
+-            basisKernel.computeImage(basisImage, True)
+-            basisImage /= np.sum(basisImage.getArray())
+-
+-            if sigma == sigma1:
+-                basisImage0 = basisImage
+-            else:
+-                basisImage -= basisImage0
+-
+-            basisKernelList.append(afwMath.FixedKernel(basisImage))
+-
+-        order = 1                                # 1 => up to linear
+-        spFunc = afwMath.PolynomialFunction2D(order)
+-
+-        exactKernel = afwMath.LinearCombinationKernel(basisKernelList, spFunc)
+-        exactKernel.setSpatialParameters([[1.0, 0, 0],
+-                                          [0.0, 0.5*1e-2, 0.2e-2]])
+-        self.exactPsf = measAlg.PcaPsf(exactKernel)
+-
+-        rand = afwMath.Random()               # make these tests repeatable by setting seed
+-
+-        addNoise = True
+-
+-        if addNoise:
+-            im = self.mi.getImage()
+-            afwMath.randomGaussianImage(im, rand)  # N(0, 1)
+-            im *= sd                              # N(0, sd^2)
+-            del im
+-
+-        xarr, yarr = [], []
+-
+-        for x, y in [(20, 20), (60, 20),
+-                     (30, 35),
+-                     (50, 50),
+-                     (20, 90), (70, 160), (25, 265), (75, 275), (85, 30),
+-                     (50, 120), (70, 80),
+-                     (60, 210), (20, 210),
+-                     ]:
+-            xarr.append(x)
+-            yarr.append(y)
+-
+-        for x, y in zip(xarr, yarr):
+-            dx = rand.uniform() - 0.5   # random (centered) offsets
+-            dy = rand.uniform() - 0.5
+-
+-            k = exactKernel.getSpatialFunction(1)(x, y)  # functional variation of Kernel ...
+-            b = (k*sigma1**2/((1 - k)*sigma2**2))       # ... converted double Gaussian's "b"
+-
+-            #flux = 80000 - 20*x - 10*(y/float(height))**2
+-            flux = 80000*(1 + 0.1*(rand.uniform() - 0.5))
+-            I0 = flux*(1 + b)/(2*np.pi*(sigma1**2 + b*sigma2**2))
+-            for iy in range(y - self.ksize//2, y + self.ksize//2 + 1):
+-                if iy < 0 or iy >= self.mi.getHeight():
+-                    continue
+-
+-                for ix in range(x - self.ksize//2, x + self.ksize//2 + 1):
+-                    if ix < 0 or ix >= self.mi.getWidth():
+-                        continue
+-
+-                    I = I0*psfVal(ix, iy, x + dx, y + dy, sigma1, sigma2, b)
+-                    Isample = rand.poisson(I) if addNoise else I
+-                    self.mi.getImage().set(ix, iy, self.mi.getImage().get(ix, iy) + Isample)
+-                    self.mi.getVariance().set(ix, iy, self.mi.getVariance().get(ix, iy) + I)
+-        #
+-        bbox = afwGeom.BoxI(afwGeom.PointI(0, 0), afwGeom.ExtentI(width, height))
+-        self.cellSet = afwMath.SpatialCellSet(bbox, 100)
+-
+-        self.footprintSet = afwDetection.FootprintSet(self.mi, afwDetection.Threshold(100), "DETECTED")
+-        self.catalog = self.measure(self.footprintSet, self.exposure)
+-
+-        for source in self.catalog:
+-            try:
+-                cand = measAlg.makePsfCandidate(source, self.exposure)
+-                self.cellSet.insertCandidate(cand)
+-
+-            except Exception as e:
+-                print(e)
+-                continue
+-
+-    def tearDown(self):
+-        del self.cellSet
+-        del self.exposure
+-        del self.mi
+-        del self.exactPsf
+-        del self.footprintSet
+-        del self.catalog
+-        del self.schema
+-        del self.measureTask
+-
+-    def setupDeterminer(self, exposure=None, nEigenComponents=2, starSelectorAlg="secondMoment"):
+-        """Setup the starSelector and psfDeterminer."""
+-        if exposure is None:
+-            exposure = self.exposure
+-
+-        starSelectorClass = measAlg.starSelectorRegistry[starSelectorAlg]
+-        starSelectorConfig = starSelectorClass.ConfigClass()
+-
+-        if starSelectorAlg == "secondMoment":
+-            starSelectorConfig.clumpNSigma = 5.0
+-            starSelectorConfig.histSize = 14
+-            starSelectorConfig.badFlags = ["base_PixelFlags_flag_edge",
+-                                           "base_PixelFlags_flag_interpolatedCenter",
+-                                           "base_PixelFlags_flag_saturatedCenter",
+-                                           "base_PixelFlags_flag_crCenter",
+-                                           ]
+-        elif starSelectorAlg == "objectSize":
+-            starSelectorConfig.sourceFluxField = "base_GaussianFlux_flux"
+-            starSelectorConfig.badFlags = ["base_PixelFlags_flag_edge",
+-                                           "base_PixelFlags_flag_interpolatedCenter",
+-                                           "base_PixelFlags_flag_saturatedCenter",
+-                                           "base_PixelFlags_flag_crCenter",
+-                                           ]
+-            starSelectorConfig.widthStdAllowed = 0.5
+-
+-        starSelector = starSelectorClass(config=starSelectorConfig, schema=self.schema)
+-
+-        psfDeterminerTask = measAlg.psfDeterminerRegistry["pca"]
+-        psfDeterminerConfig = psfDeterminerTask.ConfigClass()
+-        width, height = exposure.getMaskedImage().getDimensions()
+-        psfDeterminerConfig.sizeCellX = width
+-        psfDeterminerConfig.sizeCellY = height//3
+-        psfDeterminerConfig.nEigenComponents = nEigenComponents
+-        psfDeterminerConfig.spatialOrder = 1
+-        psfDeterminerConfig.kernelSizeMin = 31
+-        psfDeterminerConfig.nStarPerCell = 0
+-        psfDeterminerConfig.nStarPerCellSpatialFit = 0  # unlimited
+-        psfDeterminer = psfDeterminerTask(psfDeterminerConfig)
+-
+-        return starSelector, psfDeterminer
+-
+-    def subtractStars(self, exposure, catalog, chi_lim=-1):
+-        """Subtract the exposure's PSF from all the sources in catalog."""
+-        mi, psf = exposure.getMaskedImage(), exposure.getPsf()
+-
+-        subtracted = mi.Factory(mi, True)
+-
+-        for s in catalog:
+-            xc, yc = s.getX(), s.getY()
+-            bbox = subtracted.getBBox()
+-            if bbox.contains(afwGeom.PointI(int(xc), int(yc))):
+-                try:
+-                    measAlg.subtractPsf(psf, subtracted, xc, yc)
+-                except:
+-                    pass
+-
+-        chi = subtracted.Factory(subtracted, True)
+-        var = subtracted.getVariance()
+-        np.sqrt(var.getArray(), var.getArray())  # inplace sqrt
+-        chi /= var
+-
+-        if display:
+-            ds9.mtv(subtracted, title="Subtracted", frame=1)
+-            ds9.mtv(chi, title="Chi", frame=2)
+-            ds9.mtv(psf.computeImage(afwGeom.Point2D(xc, yc)), title="Psf", frame=3)
+-            ds9.mtv(mi, frame=4, title="orig")
+-            kern = psf.getKernel()
+-            kimg = afwImage.ImageD(kern.getWidth(), kern.getHeight())
+-            kern.computeImage(kimg, True, xc, yc)
+-            ds9.mtv(kimg, title="kernel", frame=5)
+-
+-        chi_min, chi_max = np.min(chi.getImage().getArray()), np.max(chi.getImage().getArray())
+-        if False:
+-            print(chi_min, chi_max)
+-
+-        if chi_lim > 0:
+-            self.assertGreater(chi_min, -chi_lim)
+-            self.assertLess(chi_max, chi_lim)
+-
+-    def testPsfDeterminer(self):
+-        """Test the (PCA) psfDeterminer."""
+-        for starSelectorAlg in ["secondMoment",
+-                                "objectSize",
+-                                ]:
+-            print("Using %s star selector" % (starSelectorAlg))
+-
+-            starSelector, psfDeterminer = self.setupDeterminer(starSelectorAlg=starSelectorAlg)
+-            metadata = dafBase.PropertyList()
+-            psfCandidateList = starSelector.run(self.exposure, self.catalog).psfCandidates
+-            psf, cellSet = psfDeterminer.determinePsf(self.exposure, psfCandidateList, metadata)
+-            self.exposure.setPsf(psf)
+-
+-            chi_lim = 5.0
+-            self.subtractStars(self.exposure, self.catalog, chi_lim)
+-
+-    def testPsfDeterminerSubimageObjectSizeStarSelector(self):
+-        """Test the (PCA) psfDeterminer on subImages."""
+-        w, h = self.exposure.getDimensions()
+-        x0, y0 = int(0.35*w), int(0.45*h)
+-        bbox = afwGeom.BoxI(afwGeom.PointI(x0, y0), afwGeom.ExtentI(w-x0, h-y0))
+-        subExp = self.exposure.Factory(self.exposure, bbox, afwImage.LOCAL)
+-
+-        starSelector, psfDeterminer = self.setupDeterminer(subExp, starSelectorAlg="objectSize")
+-        metadata = dafBase.PropertyList()
+-        #
+-        # Only keep the sources that lie within the subregion (avoiding lots of log messages)
+-        #
+-
+-        def trimCatalogToImage(exp, catalog):
+-            trimmedCatalog = afwTable.SourceCatalog(catalog.table.clone())
+-            for s in catalog:
+-                if exp.getBBox().contains(afwGeom.PointI(s.getCentroid())):
+-                    trimmedCatalog.append(trimmedCatalog.table.copyRecord(s))
+-
+-            return trimmedCatalog
+-
+-        psfCandidateList = starSelector.run(subExp, trimCatalogToImage(subExp, self.catalog)).psfCandidates
+-        psf, cellSet = psfDeterminer.determinePsf(subExp, psfCandidateList, metadata)
+-        subExp.setPsf(psf)
+-
+-        # Test how well we can subtract the PSF model.  N.b. using self.exposure is an extrapolation
+-        for exp, chi_lim in [(subExp, 4.5),
+-                             (self.exposure.Factory(self.exposure,
+-                                                    afwGeom.BoxI(afwGeom.PointI(0, 100),
+-                                                                 (afwGeom.PointI(w-1, h-1))),
+-                                                    afwImage.LOCAL), 7.5),
+-                             (self.exposure, 19),
+-                             ]:
+-            cat = trimCatalogToImage(exp, self.catalog)
+-            exp.setPsf(psf)
+-            self.subtractStars(exp, cat, chi_lim)
+-
+-    def testPsfDeterminerSubimageSecondMomentStarSelector(self):
+-        """Test the (PCA) psfDeterminer on subImages."""
+-        w, h = self.exposure.getDimensions()
+-        x0, y0 = int(0.35*w), int(0.45*h)
+-        bbox = afwGeom.BoxI(afwGeom.PointI(x0, y0), afwGeom.ExtentI(w-x0, h-y0))
+-        subExp = self.exposure.Factory(self.exposure, bbox, afwImage.LOCAL)
+-
+-        starSelector, psfDeterminer = self.setupDeterminer(subExp, starSelectorAlg="secondMoment")
+-        metadata = dafBase.PropertyList()
+-        #
+-        # Only keep the sources that lie within the subregion (avoiding lots of log messages)
+-        #
+-
+-        def trimCatalogToImage(exp, catalog):
+-            trimmedCatalog = afwTable.SourceCatalog(catalog.table.clone())
+-            for s in catalog:
+-                if exp.getBBox().contains(afwGeom.PointI(s.getCentroid())):
+-                    trimmedCatalog.append(trimmedCatalog.table.copyRecord(s))
+-
+-            return trimmedCatalog
+-
+-        psfCandidateList = starSelector.run(subExp, trimCatalogToImage(subExp, self.catalog)).psfCandidates
+-        psf, cellSet = psfDeterminer.determinePsf(subExp, psfCandidateList, metadata)
+-        subExp.setPsf(psf)
+-
+-        # Test how well we can subtract the PSF model.  N.b. using self.exposure is an extrapolation
+-        for exp, chi_lim in [(subExp, 4.5),
+-                             (self.exposure.Factory(self.exposure,
+-                                                    afwGeom.BoxI(afwGeom.PointI(0, 100),
+-                                                                 (afwGeom.PointI(w-1, h-1))),
+-                                                    afwImage.LOCAL), 7.5),
+-                             (self.exposure, 19),
+-                             ]:
+-            cat = trimCatalogToImage(exp, self.catalog)
+-            exp.setPsf(psf)
+-            self.subtractStars(exp, cat, chi_lim)
+-
+-    def testPsfDeterminerNEigenObjectSizeStarSelector(self):
+-        """Test the (PCA) psfDeterminer when you ask for more components than acceptable stars."""
+-        starSelector, psfDeterminer = self.setupDeterminer(nEigenComponents=3, starSelectorAlg="objectSize")
+-        metadata = dafBase.PropertyList()
+-        psfCandidateList = starSelector.run(self.exposure, self.catalog).psfCandidates
+-        psfCandidateList, nEigen = psfCandidateList[0:4], 2  # only enough stars for 2 eigen-components
+-        psf, cellSet = psfDeterminer.determinePsf(self.exposure, psfCandidateList, metadata)
+-
+-        self.assertEqual(psf.getKernel().getNKernelParameters(), nEigen)
+-
+-    def testPsfDeterminerNEigenSecondMomentStarSelector(self):
+-        """Test the (PCA) psfDeterminer when you ask for more components than acceptable stars."""
+-        starSelector, psfDeterminer = self.setupDeterminer(nEigenComponents=3, starSelectorAlg="secondMoment")
+-        metadata = dafBase.PropertyList()
+-        psfCandidateList = starSelector.run(self.exposure, self.catalog).psfCandidates
+-        psfCandidateList, nEigen = psfCandidateList[0:4], 2  # only enough stars for 2 eigen-components
+-        psf, cellSet = psfDeterminer.determinePsf(self.exposure, psfCandidateList, metadata)
+-
+-        self.assertEqual(psf.getKernel().getNKernelParameters(), nEigen)
+-
+-    def testCandidateList(self):
+-        self.assertFalse(self.cellSet.getCellList()[0].empty())
+-        self.assertTrue(self.cellSet.getCellList()[1].empty())
+-        self.assertFalse(self.cellSet.getCellList()[2].empty())
+-        self.assertTrue(self.cellSet.getCellList()[3].empty())
+-
+-        stamps = []
+-        for cell in self.cellSet.getCellList():
+-            for cand in cell:
+-                #
+-                # Swig doesn't know that we inherited from SpatialCellMaskedImageCandidate;  all
+-                # it knows is that we have a SpatialCellCandidate, and SpatialCellCandidates
+-                # don't know about getMaskedImage;  so cast the pointer to
+-                # SpatialCellMaskedImageCandidate<float> and all will be well
+-                #
+-                cand = afwMath.cast_SpatialCellMaskedImageCandidateF(cell[0])
+-                width, height = 29, 25
+-                cand.setWidth(width)
+-                cand.setHeight(height)
+-
+-                im = cand.getMaskedImage()
+-                stamps.append(im)
+-
+-                self.assertEqual(im.getWidth(), width)
+-                self.assertEqual(im.getHeight(), height)
+-
+-        if False and display:
+-            mos = displayUtils.Mosaic()
+-            mos.makeMosaic(stamps, frame=2)
+-
+-    def testRejectBlends(self):
+-        """Test the PcaPsfDeterminerTask blend removal."""
+-        """
+-        We give it a single blended source, asking it to remove blends,
+-        and check that it barfs in the expected way.
+-        """
+-
+-        psfDeterminerClass = measAlg.psfDeterminerRegistry["pca"]
+-        config = psfDeterminerClass.ConfigClass()
+-        config.doRejectBlends = True
+-        psfDeterminer = psfDeterminerClass(config=config)
+-
+-        schema = afwTable.SourceTable.makeMinimalSchema()
+-        # Use The single frame measurement task to populate the schema with standard keys
+-        measBase.SingleFrameMeasurementTask(schema)
+-        catalog = afwTable.SourceCatalog(schema)
+-        source = catalog.addNew()
+-
+-        # Make the source blended, with necessary information to calculate pca
+-        foot = afwDetection.Footprint(afwGeom.Point2I(45, 123), 6, self.exposure.getBBox())
+-        foot.addPeak(45, 123, 6)
+-        foot.addPeak(47, 126, 5)
+-        source.setFootprint(foot)
+-        centerKey = afwTable.Point2DKey(source.schema['slot_Centroid'])
+-        shapeKey = afwTable.QuadrupoleKey(schema['slot_Shape'])
+-        source.set(centerKey, afwTable.Point2D(46, 124))
+-        source.set(shapeKey, afwTable.Quadrupole(1.1, 2.2, 1))
+-
+-        candidates = [measAlg.makePsfCandidate(source, self.exposure)]
+-        metadata = dafBase.PropertyList()
+-
+-        with self.assertRaises(RuntimeError) as cm:
+-            psfDeterminer.determinePsf(self.exposure, candidates, metadata)
+-        self.assertEqual(str(cm.exception), "All PSF candidates removed as blends")
+-
+-
+-#-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+-
+-class TestMemory(lsst.utils.tests.MemoryTestCase):
+-    pass
+-
+-
+-def setup_module(module):
+-    lsst.utils.tests.init()
+-
+-if __name__ == "__main__":
+-    lsst.utils.tests.init()
+-    unittest.main()
+diff -ru -N tests/testPsfIO.py.orig tests/testPsfIO.py.orig
+--- tests/testPsfIO.py.orig
++++ tests/testPsfIO.py.orig	1970-01-01 00:00:00.000000000 +0000
+@@ -1,438 +0,0 @@
+-#!/usr/bin/env python
+-#
+-# LSST Data Management System
+-#
+-# Copyright 2008-2016  AURA/LSST.
+-#
+-# This product includes software developed by the
+-# LSST Project (http://www.lsst.org/).
+-#
+-# This program is free software: you can redistribute it and/or modify
+-# it under the terms of the GNU General Public License as published by
+-# the Free Software Foundation, either version 3 of the License, or
+-# (at your option) any later version.
+-#
+-# This program is distributed in the hope that it will be useful,
+-# but WITHOUT ANY WARRANTY; without even the implied warranty of
+-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-# GNU General Public License for more details.
+-#
+-# You should have received a copy of the LSST License Statement and
+-# the GNU General Public License along with this program.  If not,
+-# see <https://www.lsstcorp.org/LegalNotices/>.
+-#
+-from __future__ import absolute_import, division, print_function
+-from builtins import range
+-import os
+-import math
+-import unittest
+-
+-import numpy as np
+-
+-import lsst.utils.tests
+-import lsst.daf.base as dafBase
+-import lsst.daf.persistence as dafPersist
+-import lsst.pex.logging as logging
+-import lsst.pex.policy as policy
+-import lsst.afw.geom as afwGeom
+-import lsst.afw.image as afwImage
+-import lsst.afw.detection as afwDetection
+-import lsst.afw.math as afwMath
+-import lsst.afw.table as afwTable
+-import lsst.afw.display.utils as displayUtils
+-import lsst.meas.base as measBase
+-import lsst.meas.algorithms as algorithms
+-
+-try:
+-    type(verbose)
+-    import lsst.afw.display.ds9 as ds9
+-except NameError:
+-    display = False
+-    verbose = 0
+-    logging.Trace_setVerbosity("algorithms.psf", verbose)
+-
+-psfFileNum = 1
+-
+-
+-def roundTripPsf(key, psf):
+-    global psfFileNum
+-    pol = policy.Policy()
+-    additionalData = dafBase.PropertySet()
+-
+-    if psfFileNum % 2 == 1:
+-        storageType = "Boost"
+-    else:
+-        storageType = "Xml"
+-    loc = dafPersist.LogicalLocation(
+-        "tests/data/psf%d-%d.%s" % (psfFileNum, key, storageType))
+-    psfFileNum += 1
+-    persistence = dafPersist.Persistence.getPersistence(pol)
+-
+-    storageList = dafPersist.StorageList()
+-    storage = persistence.getPersistStorage("%sStorage" % (storageType), loc)
+-    storageList.append(storage)
+-    persistence.persist(psf, storageList, additionalData)
+-
+-    storageList2 = dafPersist.StorageList()
+-    storage2 = persistence.getRetrieveStorage("%sStorage" % (storageType), loc)
+-    storageList2.append(storage2)
+-    psfptr = persistence.unsafeRetrieve("Psf", storageList2, additionalData)
+-    psf2 = afwDetection.Psf.swigConvert(psfptr)
+-
+-    return psf2
+-
+-#-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+-
+-
+-class SpatialModelPsfTestCase(lsst.utils.tests.TestCase):
+-    """A test case for SpatialModelPsf"""
+-
+-    def setUp(self):
+-        width, height = 100, 300
+-        self.mi = afwImage.MaskedImageF(afwGeom.ExtentI(width, height))
+-        self.mi.set(0)
+-        self.mi.getVariance().set(10)
+-        self.mi.getMask().addMaskPlane("DETECTED")
+-
+-        self.FWHM = 5
+-        self.ksize = 25                      # size of desired kernel
+-
+-        self.exposure = afwImage.makeExposure(self.mi)
+-
+-        psf = roundTripPsf(2, algorithms.DoubleGaussianPsf(self.ksize, self.ksize,
+-                                                           self.FWHM/(2*math.sqrt(2*math.log(2))), 1, 0.1))
+-        self.exposure.setPsf(psf)
+-
+-        for x, y in [(20, 20),
+-                     #(30, 35), (50, 50),
+-                     (60, 20), (60, 210), (20, 210)]:
+-
+-            flux = 10000 - 0*x - 10*y
+-
+-            sigma = 3 + 0.01*(y - self.mi.getHeight()/2)
+-            psf = roundTripPsf(3, algorithms.DoubleGaussianPsf(self.ksize, self.ksize, sigma, 1, 0.1))
+-            im = psf.computeImage().convertF()
+-            im *= flux
+-            x0y0 = afwGeom.PointI(x - self.ksize//2, y - self.ksize//2)
+-            smi = self.mi.getImage().Factory(self.mi.getImage(),
+-                                             afwGeom.BoxI(x0y0, afwGeom.ExtentI(self.ksize)), afwImage.LOCAL)
+-
+-            if False:                   # Test subtraction with non-centered psfs
+-                im = afwMath.offsetImage(im, 0.5, 0.5)
+-
+-            smi += im
+-            del psf
+-            del im
+-            del smi
+-
+-        roundTripPsf(4, algorithms.DoubleGaussianPsf(self.ksize, self.ksize,
+-                                                     self.FWHM/(2*math.sqrt(2*math.log(2))), 1, 0.1))
+-
+-        self.cellSet = afwMath.SpatialCellSet(afwGeom.BoxI(afwGeom.PointI(0, 0),
+-                                                           afwGeom.ExtentI(width, height)), 100)
+-        ds = afwDetection.FootprintSet(self.mi, afwDetection.Threshold(10), "DETECTED")
+-        #
+-        # Prepare to measure
+-        #
+-        schema = afwTable.SourceTable.makeMinimalSchema()
+-        sfm_config = measBase.SingleFrameMeasurementConfig()
+-        sfm_config.plugins = ["base_SdssCentroid", "base_CircularApertureFlux", "base_PsfFlux",
+-                              "base_SdssShape", "base_GaussianFlux", "base_PixelFlags"]
+-        sfm_config.slots.centroid = "base_SdssCentroid"
+-        sfm_config.slots.shape = "base_SdssShape"
+-        sfm_config.slots.psfFlux = "base_PsfFlux"
+-        sfm_config.slots.instFlux = None
+-        sfm_config.slots.apFlux = "base_CircularApertureFlux_3_0"
+-        sfm_config.slots.modelFlux = "base_GaussianFlux"
+-        sfm_config.slots.calibFlux = None
+-        sfm_config.plugins["base_SdssShape"].maxShift = 10.0
+-        sfm_config.plugins["base_CircularApertureFlux"].radii = [3.0]
+-        task = measBase.SingleFrameMeasurementTask(schema, config=sfm_config)
+-        measCat = afwTable.SourceCatalog(schema)
+-        # detect the sources and run with the measurement task
+-        ds.makeSources(measCat)
+-        task.run(measCat, self.exposure)
+-        for source in measCat:
+-            self.cellSet.insertCandidate(algorithms.makePsfCandidate(source, self.exposure))
+-
+-    def tearDown(self):
+-        del self.exposure
+-        del self.cellSet
+-        del self.mi
+-        del self.ksize
+-        del self.FWHM
+-
+-    def testGetPcaKernel(self):
+-        """Convert our cellSet to a LinearCombinationKernel"""
+-
+-        nEigenComponents = 2
+-        spatialOrder = 1
+-        kernelSize = 21
+-        nStarPerCell = 2
+-        nStarPerCellSpatialFit = 2
+-        tolerance = 1e-5
+-
+-        if display:
+-            ds9.mtv(self.mi, frame=0)
+-            #
+-            # Show the candidates we're using
+-            #
+-            for cell in self.cellSet.getCellList():
+-                i = 0
+-                for cand in cell:
+-                    i += 1
+-                    source = algorithms.cast_PsfCandidateF(cand).getSource()
+-
+-                    xc, yc = source.getXAstrom() - self.mi.getX0(), source.getYAstrom() - self.mi.getY0()
+-                    if i <= nStarPerCell:
+-                        ds9.dot("o", xc, yc, ctype=ds9.GREEN)
+-                    else:
+-                        ds9.dot("o", xc, yc, ctype=ds9.YELLOW)
+-
+-        pair = algorithms.createKernelFromPsfCandidates(self.cellSet, self.exposure.getDimensions(),
+-                                                        self.exposure.getXY0(), nEigenComponents,
+-                                                        spatialOrder, kernelSize, nStarPerCell)
+-
+-        kernel, eigenValues = pair[0], pair[1]
+-        del pair
+-
+-        print("lambda", " ".join(["%g" % l for l in eigenValues]))
+-
+-        pair = algorithms.fitSpatialKernelFromPsfCandidates(kernel, self.cellSet, nStarPerCellSpatialFit,
+-                                                            tolerance)
+-        status, chi2 = pair[0], pair[1]
+-        del pair
+-        print("Spatial fit: %s chi^2 = %.2g" % (status, chi2))
+-
+-        psf = algorithms.PcaPsf.swigConvert(roundTripPsf(5, algorithms.PcaPsf(kernel)))  # Hurrah!
+-
+-        self.assertIsNone(afwMath.cast_AnalyticKernel(psf.getKernel()))
+-        self.assertIsNotNone(afwMath.cast_LinearCombinationKernel(psf.getKernel()))
+-
+-        self.checkTablePersistence(psf)
+-
+-        if display:
+-            # print psf.getKernel().toString()
+-
+-            eImages = []
+-            for k in afwMath.cast_LinearCombinationKernel(psf.getKernel()).getKernelList():
+-                im = afwImage.ImageD(k.getDimensions())
+-                k.computeImage(im, False)
+-                eImages.append(im)
+-
+-            mos = displayUtils.Mosaic()
+-            frame = 3
+-            ds9.mtv(mos.makeMosaic(eImages), frame=frame)
+-            ds9.dot("Eigen Images", 0, 0, frame=frame)
+-            #
+-            # Make a mosaic of PSF candidates
+-            #
+-            stamps = []
+-            stampInfo = []
+-
+-            for cell in self.cellSet.getCellList():
+-                for cand in cell:
+-                    #
+-                    # Swig doesn't know that we inherited from SpatialCellMaskedImageCandidate;  all
+-                    # it knows is that we have a SpatialCellCandidate, and SpatialCellCandidates
+-                    # don't know about getMaskedImage;  so cast the pointer to PsfCandidate
+-                    #
+-                    cand = algorithms.cast_PsfCandidateF(cand)
+-                    s = cand.getSource()
+-
+-                    im = cand.getMaskedImage()
+-
+-                    stamps.append(im)
+-                    stampInfo.append("[%d 0x%x]" % (s.getId(), s.getFlagForDetection()))
+-
+-                    mos = displayUtils.Mosaic()
+-            frame = 1
+-            ds9.mtv(mos.makeMosaic(stamps), frame=frame, lowOrderBits=True)
+-            for i in range(len(stampInfo)):
+-                ds9.dot(stampInfo[i], mos.getBBox(i).getX0(), mos.getBBox(i).getY0(), frame=frame,
+-                        ctype=ds9.RED)
+-
+-            psfImages = []
+-            labels = []
+-            if False:
+-                nx, ny = 3, 4
+-                for iy in range(ny):
+-                    for ix in range(nx):
+-                        x = int((ix + 0.5)*self.mi.getWidth()/nx)
+-                        y = int((iy + 0.5)*self.mi.getHeight()/ny)
+-
+-                        im = psf.getImage(x, y)
+-                        psfImages.append(im.Factory(im, True))
+-                        labels.append("PSF(%d,%d)" % (int(x), int(y)))
+-
+-                        if True:
+-                            print((x, y, "PSF parameters:", psf.getKernel().getKernelParameters()))
+-            else:
+-                nx, ny = 2, 2
+-                for x, y in [(20, 20), (60, 20),
+-                             (60, 210), (20, 210)]:
+-
+-                    im = psf.computeImage(afwGeom.PointD(x, y))
+-                    psfImages.append(im.Factory(im, True))
+-                    labels.append("PSF(%d,%d)" % (int(x), int(y)))
+-
+-                    if True:
+-                        print(x, y, "PSF parameters:", psf.getKernel().getKernelParameters())
+-
+-            frame = 2
+-            mos.makeMosaic(psfImages, frame=frame, mode=nx)
+-            mos.drawLabels(labels, frame=frame)
+-
+-        if display:
+-
+-            ds9.mtv(self.mi, frame=0)
+-
+-            psfImages = []
+-            labels = []
+-            if False:
+-                nx, ny = 3, 4
+-                for iy in range(ny):
+-                    for ix in range(nx):
+-                        x = int((ix + 0.5)*self.mi.getWidth()/nx)
+-                        y = int((iy + 0.5)*self.mi.getHeight()/ny)
+-
+-                        algorithms.subtractPsf(psf, self.mi, x, y)
+-            else:
+-                nx, ny = 2, 2
+-                for x, y in [(20, 20), (60, 20),
+-                             (60, 210), (20, 210)]:
+-
+-                    if False:               # Test subtraction with non-centered psfs
+-                        x += 0.5
+-                        y -= 0.5
+-
+-                    #algorithms.subtractPsf(psf, self.mi, x, y)
+-
+-            ds9.mtv(self.mi, frame=1)
+-
+-    def testCandidateList(self):
+-        if False and display:
+-            ds9.mtv(self.mi)
+-
+-            for cell in self.cellSet.getCellList():
+-                x0, y0, x1, y1 = (
+-                    cell.getBBox().getX0(), cell.getBBox().getY0(),
+-                    cell.getBBox().getX1(), cell.getBBox().getY1())
+-                print((x0, y0, " ", x1, y1))
+-                x0 -= 0.5
+-                y0 -= 0.5
+-                x1 += 0.5
+-                y1 += 0.5
+-
+-                ds9.line([(x0, y0), (x1, y0), (x1, y1), (x0, y1), (x0, y0)], ctype=ds9.RED)
+-
+-        self.assertFalse(self.cellSet.getCellList()[0].empty())
+-        self.assertTrue(self.cellSet.getCellList()[1].empty())
+-        self.assertFalse(self.cellSet.getCellList()[2].empty())
+-
+-        stamps = []
+-        for cell in self.cellSet.getCellList():
+-            for cand in cell:
+-                #
+-                # Swig doesn't know that we inherited from SpatialCellMaskedImageCandidate;  all
+-                # it knows is that we have a SpatialCellCandidate, and SpatialCellCandidates
+-                # don't know about getMaskedImage;  so cast the pointer to
+-                # SpatialCellMaskedImageCandidate<float> and all will be well
+-                #
+-                cand = afwMath.cast_SpatialCellMaskedImageCandidateF(cell[0])
+-                width, height = 15, 17
+-                cand.setWidth(width)
+-                cand.setHeight(height)
+-
+-                im = cand.getMaskedImage()
+-                stamps.append(im)
+-
+-                self.assertEqual(im.getWidth(), width)
+-                self.assertEqual(im.getHeight(), height)
+-
+-        if display:
+-            mos = displayUtils.Mosaic()
+-            ds9.mtv(mos.makeMosaic(stamps), frame=1)
+-
+-    def checkTablePersistence(self, psf1):
+-        """Called by testGetPcaKernel to test table-based persistence; it's a pain to
+-        build a PcaPsf, so we don't want to repeat it all for each test case.
+-
+-        We just verify here that we get a LinearCombinationKernel; all the details of
+-        testing that we get the *right* one are tested more thoroughly in afw.
+-        """
+-        print("Testing PcaPsf!")
+-        filename = "PcaPsf.fits"
+-        psf1.writeFits(filename)
+-        psf2 = algorithms.PcaPsf.readFits(filename)
+-        self.assertIsNotNone(psf2)
+-        self.assertIsNotNone(psf2.getKernel())
+-        self.assertIsNotNone(afwMath.LinearCombinationKernel.swigConvert(psf2.getKernel()))
+-        os.remove(filename)
+-
+-#-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+-
+-
+-class SingleGaussianPsfTestCase(unittest.TestCase):
+-
+-    def testTablePersistence(self):
+-        filename = "SingleGaussianPsf.fits"
+-        psf1 = algorithms.SingleGaussianPsf(5, 7, 4.2)
+-        psf1.writeFits(filename)
+-        psf2 = algorithms.SingleGaussianPsf.readFits(filename)
+-        self.assertEqual(psf1.getSigma(), psf2.getSigma())
+-        os.remove(filename)
+-
+-
+-class DoubleGaussianPsfTestCase(unittest.TestCase):
+-    """A test case for DoubleGaussianPsf"""
+-
+-    def comparePsfs(self, psf1, psf2):
+-        self.assertTrue(isinstance(psf1, algorithms.DoubleGaussianPsf))
+-        self.assertTrue(isinstance(psf2, algorithms.DoubleGaussianPsf))
+-        self.assertEqual(psf1.getKernel().getWidth(), psf2.getKernel().getWidth())
+-        self.assertEqual(psf1.getKernel().getHeight(), psf2.getKernel().getHeight())
+-        self.assertEqual(psf1.getSigma1(), psf2.getSigma1())
+-        self.assertEqual(psf1.getSigma2(), psf2.getSigma2())
+-        self.assertEqual(psf1.getB(), psf2.getB())
+-
+-    def setUp(self):
+-        self.ksize = 25                      # size of desired kernel
+-        FWHM = 5
+-        self.sigma1 = FWHM/(2*np.sqrt(2*np.log(2)))
+-        self.sigma2 = 2*self.sigma1
+-        self.b = 0.1
+-
+-    def tearDown(self):
+-        del self.ksize
+-        del self.sigma1
+-        del self.sigma2
+-        del self.b
+-
+-    def testBoostPersistence(self):
+-        psf1 = algorithms.DoubleGaussianPsf(self.ksize, self.ksize, self.sigma1, self.sigma2, self.b)
+-        psf2 = roundTripPsf(1, psf1)
+-        psf3 = roundTripPsf(1, psf1)
+-        self.comparePsfs(psf1, algorithms.DoubleGaussianPsf.swigConvert(psf2))
+-        self.comparePsfs(psf1, algorithms.DoubleGaussianPsf.swigConvert(psf3))
+-
+-    def testFitsPersistence(self):
+-        psf1 = algorithms.DoubleGaussianPsf(self.ksize, self.ksize, self.sigma1, self.sigma2, self.b)
+-        filename = "tests/data/psf1-1.fits"
+-        psf1.writeFits(filename)
+-        psf2 = algorithms.DoubleGaussianPsf.readFits(filename)
+-        self.comparePsfs(psf1, psf2)
+-
+-#-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+-
+-
+-class TestMemory(lsst.utils.tests.MemoryTestCase):
+-    pass
+-
+-
+-def setup_module(module):
+-    lsst.utils.tests.init()
+-
+-if __name__ == "__main__":
+-    lsst.utils.tests.init()
+-    unittest.main()

--- a/etc/recipes/lsst-ndarray/000-patch-eups-to-remove-fft-test.patch
+++ b/etc/recipes/lsst-ndarray/000-patch-eups-to-remove-fft-test.patch
@@ -1,0 +1,30 @@
+diff --git patches/000-remove-fft-test.patch patches/000-remove-fft-test.patch
+new file mode 100644
+index 0000000..20002ab
+--- /dev/null
++++ patches/000-remove-fft-test.patch
+@@ -0,0 +1,24 @@
++diff -ru a/tests/CMakeLists.txt b/tests/CMakeLists.txt
++--- a/tests/CMakeLists.txt	2016-09-26 12:37:12.000000000 -0700
+++++ b/tests/CMakeLists.txt	2016-09-23 19:51:37.000000000 -0700
++@@ -12,7 +12,7 @@
++ 
++ add_test(test_ndarray ndarray)
++ add_test(test_views views)
++-add_test(test_ndarray-fft ndarray-fft)
+++# add_test(test_ndarray-fft ndarray-fft)
++ add_test(test_ndarray_eigen ndarray-eigen)
++ 
++ if(NDARRAY_SWIG)
++diff -ru a/tests/SConscript b/tests/SConscript
++--- a/tests/SConscript	2016-09-26 12:37:16.000000000 -0700
+++++ b/tests/SConscript	2016-09-23 19:49:02.000000000 -0700
++@@ -45,7 +45,7 @@
++         BinaryUnitTest(testEnv, "ndarray-eigen.cc")
++     if testEnv.haveFFTW:
++         fftwEnv = testEnv.Clone()
++-        BinaryUnitTest(fftwEnv, "ndarray-fft.cc")
+++        # BinaryUnitTest(fftwEnv, "ndarray-fft.cc")
++ 
++ if pyEnv.havePython:
++     mod = pyEnv.LoadableModule("python_test_mod", "python_test_mod.cc", SHLIBPREFIX="")

--- a/etc/recipes/lsst-ndarray/build.sh
+++ b/etc/recipes/lsst-ndarray/build.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+#
+# The conda-build build script to build eupspkg-packaged code
+#
+
+# Find the true source root: conda tries to be helpful and
+# changes into the first non-empty directory given a github repository; 
+export SRC_DIR=$(git rev-parse --show-toplevel)
+cd $SRC_DIR
+
+#
+# Adjust OS-X specific parameters
+#
+if [[ "$OSTYPE" == darwin* ]]; then
+	# - Can't run earlier than Mountain Lion (10.8)
+	# (astrometry.net build breaks (at least))
+	# - Can't run earlier than Mavericks
+	# (boost won't build otherwise; 10.9 switched to libc++)
+    	export MACOSX_DEPLOYMENT_TARGET=""
+	export CMAKE_OSX_SYSROOT="/"
+	# Make sure there's enough room in binaries for the install_name_tool magic
+	# to work
+	export LDFLAGS="$LDFLAGS -headerpad_max_install_names"
+
+#	# Make sure binaries (e.g., tests) get built with enough
+#	# padding in the header for the install_name_tool to work
+#	# (sconsUtils adds the contents of this variable to CCFLAGS and LINKFLAGS)
+#	export ARCHFLAGS='-headerpad_max_install_names'
+
+	if [[ "$(ld -v 2>&1 | grep -Eow 'PROJECT:.*')" == "PROJECT:ld64-264.3.101" ]]; then
+		echo "You're running XCode 7.3, with a broken linker (version ld64-264.3.101): implementing a workaround for the @rpath expansion bug".
+		XCODE_73_RPATH_BUG=1
+	fi
+fi
+
+# Add Anaconda's library path to DYLD_LIBRARY_PATH, to make the libraries visible
+# to the builds
+if [[ "$OSTYPE" == darwin* ]]; then
+	export DYLD_FALLBACK_LIBRARY_PATH="$DYLD_LIBRARY_PATH:$CONDA_DEFAULT_ENV/lib"
+else
+	export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$CONDA_DEFAULT_ENV/lib"
+fi
+
+
+############################################################################
+# Build the package using eupspkg
+#
+PRODUCT=$(basename ups/*.table .table)
+EUPS_VERSION="1.2.0.lsst1"
+PREFIX="$PREFIX/opt/lsst/$PRODUCT"
+
+# initialize EUPS
+source eups-setups.sh
+
+# prepare
+eupspkg PREFIX="$PREFIX" PRODUCT="$PRODUCT" VERSION="$EUPS_VERSION" FLAVOR=generic prep
+
+# setup dependencies (just for the environmental variables, really)
+# FIXME: a command should be added to eupspkg to just get the envvars
+eups list
+
+setup -r .
+export
+
+#
+# make debugging easier -- if the build breaks, make it possible to chdir into the
+# build directory and run ./_build.sh <verb>
+#
+cat > _build.sh <<-EOT
+	#!/bin/bash
+	$(export)
+
+	# XCODE_73_RPATH_BUG workaround?
+	if [[ "$XCODE_73_RPATH_BUG" == 1 ]]; then
+	    trap '{ rm -f @rpath; rm -rf "$PREFIX/@rpath"; }' EXIT
+	    ln -fs "\$CONDA_DEFAULT_ENV/lib" @rpath
+	fi
+
+	PRODUCT="$PRODUCT"
+	EUPS_VERSION="$EUPS_VERSION"
+
+	eupspkg PREFIX="$PREFIX" PRODUCT="$PRODUCT" VERSION="$EUPS_VERSION" FLAVOR=generic "\$@"
+EOT
+chmod +x _build.sh
+
+# configure, build, install, declare to EUPS
+./_build.sh config
+./_build.sh build
+./_build.sh install
+./_build.sh decl
+
+# Add EUPS tags.  The tags will be stored in a file in the product's ups
+# dir; it will be merged by the pre-link.sh script with the EUPS database
+# when the package is installed
+TAGFILE="$EUPS_PATH/ups_db/global.tags"
+for TAG in current conda; do
+	# FIXME: This should be handled by the post-link/pre-delete script !!!
+	test -f "$TAGFILE" && echo -n " " >> "$TAGFILE"
+	echo -n "$TAG" >> "$TAGFILE"
+
+	eups declare -t $TAG "$PRODUCT" "$EUPS_VERSION"
+done
+mv "$TAGFILE" "$PREFIX/ups"
+
+
+############################################################################
+# Binary preparation, directory cleanups
+#
+
+# compile all .py and .cfg files so they don't get picked up as new by conda
+# when building other packages
+if [[ -d "$PREFIX/python" ]]; then
+	# don't fail in case of syntax errors, etc.
+	"$PYTHON" -m compileall "$PREFIX/python" || true
+fi
+if ls "$PREFIX/ups"/*.cfg 1> /dev/null 2>&1; then
+	"$PYTHON" -m py_compile "$PREFIX/ups"/*.cfg
+fi

--- a/etc/recipes/lsst-ndarray/meta.yaml
+++ b/etc/recipes/lsst-ndarray/meta.yaml
@@ -1,0 +1,48 @@
+#
+# Run `conda build .` to build this package
+#
+
+package:
+  name: "lsst-ndarray"
+  version: "1.2.0.1"
+
+source:
+  git_rev: "f968e944ffa8c773c3804511af019d8d1c7fcf32"
+  git_url: "https://github.com/LSST/ndarray"
+  patches:
+        - 000-patch-eups-to-remove-fft-test.patch
+
+build:
+  number: 0
+  string: "0"
+#  binary_relocation: false
+
+requirements:
+  build:
+    - eups >=2.0.2
+    - lsst-boost ==1.60.1
+    - lsst-eigen ==3.2.5.2
+    - lsst-fftw ==3.3.4.2
+    - lsst-numpy-eups-configs ==0.0.3
+    - lsst-python-eups-configs ==0.0.5
+    - lsst-swig-eups-configs ==3.0.10
+    - nomkl                         #
+    - numpy 1.10.4
+    - python 2.7.*
+    - swig ==3.0.10
+
+  run:
+    - eups >=2.0.2
+    - libgcc >=4.8.5                # [not osx]
+    - lsst-boost ==1.60.1
+    - lsst-eigen ==3.2.5.2
+    - lsst-fftw ==3.3.4.2
+    - lsst-numpy-eups-configs ==0.0.3
+    - lsst-python-eups-configs ==0.0.5
+    - lsst-swig-eups-configs ==3.0.10
+    - nomkl                         #
+
+about:
+  home: "https://github.com/LSST/ndarray"
+#  license: GPLv2
+#  summary: A version manager tracking product dependencies

--- a/etc/recipes/lsst-ndarray/pre-link.sh
+++ b/etc/recipes/lsst-ndarray/pre-link.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Fail immediately if something's wrong
+set -e
+
+# Write into this file for anything that the user should see
+OUT="$PREFIX/.messages.txt"
+
+# Adjust SOURCE_DIR (for convenience)
+SOURCE_DIR="$SOURCE_DIR/opt/lsst/ndarray"
+
+# Add $PREFIX/bin to $PATH; it's not on the path when run
+# in _build environment (is this a bug in conda-build?)
+export PATH="$PREFIX/bin:$PATH"
+
+# initialize EUPS
+source eups-setups.sh
+
+# Merge the EUPS tags used by this package with the global EUPS database
+#
+IFS=':' read -ra EUPS_PATH_ARR <<< "$EUPS_PATH"
+TAGFILE="${EUPS_PATH_ARR[0]}/ups_db/global.tags"
+
+# We need to merge the tags in the existing global.tags file, with any new
+# tags that our product needs:
+#
+# What the magic below does (in order):
+#   * cat both files, ensuring there's a newline between them
+#   * convert whitespaces to newlines
+#   * sort & run uniq
+#   * remove any empty lines
+#   * translate newlines back to whitespaces
+touch "$TAGFILE"						# make sure it exists
+awk 'FNR==1{print ""}1' "$SOURCE_DIR/ups/global.tags" "$TAGFILE" | 	\
+		tr ' ' '\n' | \
+		sort -u     | \
+		awk 'NF'    | \
+		tr '\n' ' ' \
+		> "$TAGFILE".tmp
+
+# Move the new file into place
+mv "$TAGFILE".tmp "$TAGFILE"


### PR DESCRIPTION
### Summary

Minor fixups and other required changes to conda-lsst while creating the v12.1 Conda binaries.

### Update ./etc/config.yaml for v12.1 build.

* Remove auto include of the Conda GCC package. Instead the build
        with use the system GCC which is 5.2.0.
* Use the git-rev feature to use a newer version of MariaDB and
        MariaDBClient since these do not build properly on CentOS5.
* Use a range of version for run parameter for numpy and astropy.

### Use patches and no special recipe for MariaDB and MariaDBClient.

* Prefer patches and templated recipes over special snowflakes.

            new file:   etc/patches/mariadb/010-el5.patch
            new file:   etc/patches/mariadbclient/010-el5.patch
            deleted:    etc/recipes/lsst-mariadb/build.sh
            deleted:    etc/recipes/lsst-mariadb/meta.yaml
            deleted:    etc/recipes/lsst-mariadb/pre-link.sh
            deleted:    etc/recipes/lsst-mariadbclient/build.sh
            deleted:    etc/recipes/lsst-mariadbclient/meta.yaml
            deleted:    etc/recipes/lsst-mariadbclient/pre-link.sh

### `pip install future` because the Conda recipe is broken.

* Pip install future in the eupspkg.cfg.sh to avoid non-sense.
* Eups and Conda don't seem to work correctly when trying to use the conda-forge
   version. The default version has a bug where it doesn't properly install the scripts.

            new file:   etc/patches/galsim/010-pip-install-future.patch

### Remove special lsst-fftw and lsst-wcslib recipes.

* These very specific changes were only needed when building on CentOS5
   with the Conda GCC 4.8.5 package.

            deleted:    etc/recipes/lsst-fftw/000_use_gcc_std_gnu89.patch
            deleted:    etc/recipes/lsst-fftw/build.sh
            deleted:    etc/recipes/lsst-fftw/meta.yaml
            deleted:    etc/recipes/lsst-fftw/pre-link.sh
            deleted:    etc/recipes/lsst-wcslib/000_use_gcc_std_gnu89.patch
            deleted:    etc/recipes/lsst-wcslib/build.sh
            deleted:    etc/recipes/lsst-wcslib/meta.yaml
            deleted:    etc/recipes/lsst-wcslib/pre-link.sh

### Patches to apply DM-8029.

* Apply the changes required for DM-8029 across afw, ip_diffim and meas_algorithm. There is probably some nonsense going on here since I kept having .orig files appear when apply patches through git and had to work around it.

            new file:   etc/patches/afw/010-rework-testSpatialCell-DM-8029.patch
            new file:   etc/patches/afw/020-remove-testSpatialCell.py.orig-DM-8029.patch
            new file:   etc/patches/ip_diffim/005-KernelCandidate-changes-DM-8029.patch
            new file:   etc/patches/ip_diffim/010-SpatialCell-changes-DM-8029.patch
            new file:   etc/patches/meas_algorithms/010-adapt-to-SpatialCell-changes-DM-8029.patch
            new file:   etc/patches/meas_algorithms/020-remove-orig-files-DM-8029.patch

### Remove failing ndarray test.

* This is DM-7701 but was not applied upstream yet.

            new file:   etc/recipes/lsst-ndarray/000-patch-eups-to-remove-fft-test.patch
            new file:   etc/recipes/lsst-ndarray/build.sh
            new file:   etc/recipes/lsst-ndarray/meta.yaml
            new file:   etc/recipes/lsst-ndarray/pre-link.sh

### Don't use the Conda GCC package with lsst-ndarray.

      * Update ndarray to not use Conda GCC package. We use the system gcc now.

            modified:   etc/recipes/lsst-ndarray/meta.yaml