### PR TITLE
[DM-8177] Use sqlalchemy 1.0 and specify dependencies on it.

### DIFF
--- a/etc/config.yaml
+++ b/etc/config.yaml
@@ -168,6 +168,9 @@ pin_versions:
   scipy:
     build: "0.16.*"
     run:   ">=0.16"
+  sqlalchemy:
+    build: "1.0.*"
+    run: "1.0.*"
 
 #
 # which packages to build on which OS. The effect of this will be to add

--- a/etc/config.yaml
+++ b/etc/config.yaml
@@ -91,6 +91,9 @@ dependencies:
   sims_catalogs_generation:
     run:   [ sqlalchemy ]
     build: [ sqlalchemy ]
+  sims_catutils:
+    run:   [ pandas, sqlalchemy ]
+    build: [ pandas, sqlalchemy ]
   sims_skybrightness:
     run:   [ sqlalchemy ]
     build: [ sqlalchemy ]


### PR DESCRIPTION
There was a major version release for sqlalchemy this broke the sims libraries that depended o nsqlalchemy 1.0 specifically.

* Pin sqlalchemy version 1.0.
* Specify sqlalchemy as a dependency of sims_catUtils/sims-catutils. Without this, conda-lsst still provides the sqlalchemy dependency but it's not pinned at 1.0.